### PR TITLE
Add SCSS compilation and static asset serving for embedded builds

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -139,6 +139,10 @@ fn write_files(project_root: &Path, name: &str) -> Result<(), InitError> {
             project_root.join("backend/src/api/mod.rs"),
             templates::backend_api_mod(name),
         ),
+        (
+            project_root.join("backend/src/static_assets.rs"),
+            templates::backend_static_assets_rs().to_string(),
+        ),
         // Frontend
         (
             project_root.join("frontend/Cargo.toml"),
@@ -210,6 +214,7 @@ mod tests {
         assert!(root.path().join("my-app/flux.toml").exists());
         assert!(root.path().join("my-app/backend/build.rs").exists());
         assert!(root.path().join("my-app/backend/src/main.rs").exists());
+        assert!(root.path().join("my-app/backend/src/static_assets.rs").exists());
         assert!(root.path().join("my-app/frontend/Cargo.toml").exists());
         assert!(root.path().join("my-app/frontend/src/lib.rs").exists());
         assert!(root.path().join("my-app/frontend/index.html").exists());
@@ -246,6 +251,7 @@ mod tests {
         let contents = std::fs::read_to_string(root.path().join("my-app/.gitignore")).unwrap();
         assert!(contents.contains("target/"));
         assert!(contents.contains("frontend/pkg/"));
+        assert!(contents.contains("frontend/styles/screen.css"));
     }
 
     #[test]

--- a/src/init/templates.rs
+++ b/src/init/templates.rs
@@ -56,6 +56,11 @@ pub fn backend_main_rs() -> &'static str {
     include_str!("templates/backend/main.rs")
 }
 
+/// Backend static_assets.rs
+pub fn backend_static_assets_rs() -> &'static str {
+    include_str!("templates/backend/src/static_assets.rs")
+}
+
 /// Backend API module
 pub fn backend_api_mod(name: &str) -> String {
     let crate_name = name.replace('-', "_");

--- a/src/init/templates/backend/build.rs
+++ b/src/init/templates/backend/build.rs
@@ -6,7 +6,16 @@ fn main() {
             panic!(
                 "\n\nembedding assets requires frontend/pkg/ to exist and be non-empty.\n\
                  Run this first:\n\n  \
-                 wasm-pack build frontend/ --target web --release\n\n"
+                 flux-wasm-builder release\n\n"
+            );
+        }
+
+        let css = std::path::Path::new("../frontend/styles/screen.css");
+        if !css.exists() {
+            panic!(
+                "\n\nembedding assets requires frontend/styles/screen.css to exist.\n\
+                 Run this first:\n\n  \
+                 flux-wasm-builder release\n\n"
             );
         }
     }

--- a/src/init/templates/backend/main.rs
+++ b/src/init/templates/backend/main.rs
@@ -1,20 +1,31 @@
-use actix_web::{App, HttpServer};
+use actix_web::{App, HttpServer, web};
 use tracing_subscriber::{fmt, EnvFilter};
 
 mod api;
+
+#[cfg(feature = "embed-assets")]
+mod static_assets;
 
 #[actix_web::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     init_tracing();
 
     let port: u16 = std::env::var("FLUX_BACKEND_PORT")
-    .ok()
-    .and_then(|s| s.parse().ok())
-    .unwrap_or(3001);
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3001);
 
     HttpServer::new(move || {
-        App::new()
-            .configure(api::configure)
+        let app = App::new()
+            .configure(api::configure);
+
+        #[cfg(feature = "embed-assets")]
+        let app = app
+            .service(web::resource("/pkg/{filename}").route(web::get().to(static_assets::serve_pkg_file)))
+            .route("/styles/screen.css", web::get().to(static_assets::serve_css))
+            .default_service(web::to(static_assets::spa_fallback));
+
+        app
     })
     .bind(("127.0.0.1", port))?
     .run()

--- a/src/init/templates/backend/src/static_assets.rs
+++ b/src/init/templates/backend/src/static_assets.rs
@@ -1,0 +1,48 @@
+#[cfg(feature = "embed-assets")]
+use actix_web::{HttpResponse, Responder, web};
+
+#[cfg(feature = "embed-assets")]
+static EMBEDDED_PKG: include_dir::Dir =
+    include_dir::include_dir!("$CARGO_MANIFEST_DIR/../frontend/pkg");
+
+#[cfg(feature = "embed-assets")]
+static EMBEDDED_INDEX: &[u8] = include_bytes!(
+    concat!(env!("CARGO_MANIFEST_DIR"), "/../frontend/index.html")
+);
+
+#[cfg(feature = "embed-assets")]
+static EMBEDDED_CSS: &[u8] = include_bytes!(
+    concat!(env!("CARGO_MANIFEST_DIR"), "/../frontend/styles/screen.css")
+);
+
+#[cfg(feature = "embed-assets")]
+pub async fn serve_pkg_file(path: web::Path<String>) -> impl Responder {
+    let filename = path.into_inner();
+    let safe_name = match std::path::Path::new(&filename).file_name() {
+        Some(n) => n.to_owned(),
+        None => return HttpResponse::BadRequest().body("invalid filename"),
+    };
+    match EMBEDDED_PKG.get_file(&safe_name) {
+        Some(file) => {
+            let mime = mime_guess::from_path(&safe_name).first_or_octet_stream();
+            HttpResponse::Ok()
+                .content_type(mime.to_string())
+                .body(file.contents().to_vec())
+        }
+        None => HttpResponse::NotFound().finish(),
+    }
+}
+
+#[cfg(feature = "embed-assets")]
+pub async fn serve_css() -> impl Responder {
+    HttpResponse::Ok()
+        .content_type("text/css; charset=utf-8")
+        .body(EMBEDDED_CSS.to_vec())
+}
+
+#[cfg(feature = "embed-assets")]
+pub async fn spa_fallback() -> impl Responder {
+    HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(EMBEDDED_INDEX.to_vec())
+}

--- a/src/init/templates/gitignore
+++ b/src/init/templates/gitignore
@@ -1,2 +1,3 @@
 target/
 frontend/pkg/
+frontend/styles/screen.css

--- a/src/release/mod.rs
+++ b/src/release/mod.rs
@@ -14,6 +14,8 @@ pub enum ReleaseError {
     WasmPackFailed,
     #[error("cargo build failed")]
     CargoFailed,
+    #[error("scss compilation failed: {0}")]
+    ScssFailed(String),
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -27,6 +29,14 @@ pub async fn run() -> Result<(), ReleaseError> {
     run_wasm_pack(&build_config)
         .await
         .map_err(|_| ReleaseError::WasmPackFailed)?;
+
+    println!("Compiling styles...");
+    let styles_path = std::env::current_dir()?.join("frontend/styles");
+    let css = grass::from_path(
+        &styles_path.join("screen.scss"),
+        &grass::Options::default(),
+    ).map_err(|e| ReleaseError::ScssFailed(e.to_string()))?;
+    std::fs::write(styles_path.join("screen.css"), css)?;
 
     println!("Building backend...");
     let status = Command::new("cargo")


### PR DESCRIPTION
## Summary
This PR adds SCSS stylesheet compilation and static asset serving capabilities to the Flux framework. It enables the backend to serve compiled CSS and frontend assets when the `embed-assets` feature is enabled, and integrates SCSS compilation into the release build process.

## Key Changes

- **New static asset serving module** (`backend/src/static_assets.rs`): Implements three handler functions for serving embedded frontend assets:
  - `serve_pkg_file()`: Serves compiled WebAssembly package files with correct MIME types
  - `serve_css()`: Serves the compiled stylesheet
  - `spa_fallback()`: Provides SPA fallback routing by serving `index.html`

- **SCSS compilation in release process** (`src/release/mod.rs`): 
  - Integrated `grass` crate to compile `screen.scss` to `screen.css` during release builds
  - Added `ScssFailed` error variant to handle compilation failures
  - Compilation runs after WASM build and before backend build

- **Backend routing configuration** (`backend/main.rs`):
  - Conditionally registers static asset routes when `embed-assets` feature is enabled
  - Routes `/pkg/{filename}` to serve WASM package files
  - Routes `/styles/screen.css` to serve compiled stylesheet
  - Sets up SPA fallback for unmatched routes

- **Build script updates** (`backend/build.rs`):
  - Added validation for `frontend/styles/screen.css` existence
  - Updated error messages to reference `flux-wasm-builder` command

- **Project initialization** (`src/init/mod.rs`):
  - Added `static_assets.rs` to generated backend project files
  - Updated `.gitignore` template to exclude generated `screen.css`
  - Added test assertions for new generated files

## Implementation Details

- All static asset serving is gated behind the `embed-assets` feature flag to keep the binary lightweight when assets aren't embedded
- The SCSS compilation uses the `grass` crate for Rust-native compilation without external dependencies
- File path validation in `serve_pkg_file()` prevents directory traversal attacks by extracting only the filename
- MIME type detection is automatic based on file extensions using the `mime_guess` crate

https://claude.ai/code/session_01XPUJggKpDQdwUPfZeHGrkq