### PR TITLE
Add missing tests and fix stale test to bring suite current

### DIFF
--- a/src/build/scss.rs
+++ b/src/build/scss.rs
@@ -18,3 +18,54 @@ pub fn compile_scss(styles_path: &Path) -> Result<Vec<u8>, ScssError> {
         .map_err(|e| ScssError::CompileFailed(e.to_string()))?;
     Ok(css.into_bytes())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn compile_scss_produces_non_empty_css() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("screen.scss"), "body { color: red; }").unwrap();
+        let result = compile_scss(dir.path()).unwrap();
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn compile_scss_output_is_valid_utf8() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("screen.scss"), "h1 { font-size: 2rem; }").unwrap();
+        let result = compile_scss(dir.path()).unwrap();
+        assert!(std::str::from_utf8(&result).is_ok());
+    }
+
+    #[test]
+    fn compile_scss_expands_nesting() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("screen.scss"),
+            ".parent { color: red; .child { color: blue; } }",
+        )
+        .unwrap();
+        let result = compile_scss(dir.path()).unwrap();
+        let css = std::str::from_utf8(&result).unwrap();
+        assert!(css.contains(".parent .child"), "nested SCSS should be expanded");
+    }
+
+    #[test]
+    fn compile_scss_fails_for_missing_file() {
+        let dir = tempdir().unwrap();
+        // No screen.scss written
+        let result = compile_scss(dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn compile_scss_fails_for_invalid_scss() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("screen.scss"), "this is not valid scss }{}{").unwrap();
+        let result = compile_scss(dir.path());
+        assert!(matches!(result, Err(ScssError::CompileFailed(_))));
+    }
+}

--- a/src/dev/mod.rs
+++ b/src/dev/mod.rs
@@ -58,10 +58,7 @@ pub async fn run() -> Result<(), DevError> {
     let build_config = BuildConfig::new(std::env::current_dir()?.join("frontend"));
     println!("Building frontend...");
     run_wasm_pack(&build_config).await.map_err(|_| {
-        DevError::Io(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "initial wasm-pack build failed",
-        ))
+        DevError::Io(std::io::Error::other("initial wasm-pack build failed"))
     })?;
     let build_config_for_serve = build_config.clone(); // ← clone before it moves into the spawn
     tokio::spawn(async move {

--- a/src/release/mod.rs
+++ b/src/release/mod.rs
@@ -33,7 +33,7 @@ pub async fn run() -> Result<(), ReleaseError> {
     println!("Compiling styles...");
     let styles_path = std::env::current_dir()?.join("frontend/styles");
     let css = grass::from_path(
-        &styles_path.join("screen.scss"),
+        styles_path.join("screen.scss"),
         &grass::Options::default(),
     ).map_err(|e| ReleaseError::ScssFailed(e.to_string()))?;
     std::fs::write(styles_path.join("screen.css"), css)?;

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -28,14 +28,14 @@ fn init_prints_success_message_with_project_name() {
 }
 
 #[test]
-fn init_prints_cargo_backend_next_step() {
+fn init_prints_flux_wasm_builder_dev_next_step() {
     let dir = tempdir().unwrap();
     cargo_bin_cmd!("flux-wasm-builder")
         .args(["init", "test-project"])
         .current_dir(dir.path())
         .assert()
         .success()
-        .stdout(contains("cargo backend"));
+        .stdout(contains("flux-wasm-builder dev"));
 }
 
 #[test]
@@ -56,6 +56,95 @@ fn init_requires_name_argument() {
         .args(["init"])
         .assert()
         .failure();
+}
+
+#[test]
+fn init_creates_styles_directory_and_screen_scss() {
+    let dir = tempdir().unwrap();
+    cargo_bin_cmd!("flux-wasm-builder")
+        .args(["init", "test-app"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    assert!(dir.path().join("test-app/frontend/styles").exists());
+    assert!(dir.path().join("test-app/frontend/styles/screen.scss").exists());
+}
+
+#[test]
+fn init_creates_static_assets_rs() {
+    let dir = tempdir().unwrap();
+    cargo_bin_cmd!("flux-wasm-builder")
+        .args(["init", "test-app"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    assert!(dir.path().join("test-app/backend/src/static_assets.rs").exists());
+}
+
+#[test]
+fn init_screen_scss_is_non_empty() {
+    let dir = tempdir().unwrap();
+    cargo_bin_cmd!("flux-wasm-builder")
+        .args(["init", "test-app"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let contents = std::fs::read_to_string(
+        dir.path().join("test-app/frontend/styles/screen.scss")
+    ).unwrap();
+    assert!(!contents.is_empty(), "screen.scss should not be empty");
+    assert!(contents.contains("box-sizing"), "screen.scss should contain CSS reset");
+}
+
+#[test]
+fn init_static_assets_rs_has_embed_assets_cfg_gate() {
+    let dir = tempdir().unwrap();
+    cargo_bin_cmd!("flux-wasm-builder")
+        .args(["init", "test-app"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let contents = std::fs::read_to_string(
+        dir.path().join("test-app/backend/src/static_assets.rs")
+    ).unwrap();
+    assert!(contents.contains("embed-assets"), "static_assets.rs should be cfg-gated on embed-assets");
+    assert!(contents.contains("spa_fallback"), "static_assets.rs should contain spa_fallback handler");
+    assert!(contents.contains("serve_pkg_file"), "static_assets.rs should contain serve_pkg_file handler");
+    assert!(contents.contains("serve_css"), "static_assets.rs should contain serve_css handler");
+}
+
+#[test]
+fn init_index_html_links_screen_css() {
+    let dir = tempdir().unwrap();
+    cargo_bin_cmd!("flux-wasm-builder")
+        .args(["init", "test-app"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let contents = std::fs::read_to_string(
+        dir.path().join("test-app/frontend/index.html")
+    ).unwrap();
+    assert!(contents.contains("/styles/screen.css"), "index.html should link to /styles/screen.css");
+}
+
+#[test]
+fn init_gitignore_excludes_compiled_css() {
+    let dir = tempdir().unwrap();
+    cargo_bin_cmd!("flux-wasm-builder")
+        .args(["init", "test-app"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let contents = std::fs::read_to_string(
+        dir.path().join("test-app/.gitignore")
+    ).unwrap();
+    assert!(contents.contains("screen.css"), ".gitignore should exclude compiled screen.css");
 }
 
 #[test]

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -1,0 +1,76 @@
+// tests/proxy.rs
+
+use actix_web::{App, HttpResponse, test, web};
+use flux_wasm_builder::dev::proxy::proxy_handler;
+use flux_wasm_builder::domain::{DevConfig, FluxConfig, ProjectConfig};
+
+fn make_config(backend_port: u16) -> FluxConfig {
+    FluxConfig {
+        project: ProjectConfig { name: "test".to_string() },
+        dev: DevConfig {
+            public_port: 8080,
+            backend_port,
+            watch_debounce_ms: 300,
+        },
+    }
+}
+
+#[actix_web::test]
+async fn proxy_returns_502_when_backend_unreachable() {
+    // Port 19999 should have nothing listening
+    let config = make_config(19999);
+    let client = reqwest::Client::new();
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(client))
+            .app_data(web::Data::new(config))
+            .service(web::scope("/api").default_service(web::to(proxy_handler))),
+    )
+    .await;
+
+    let req = test::TestRequest::get().uri("/api/hello").to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 502);
+}
+
+#[actix_web::test]
+async fn proxy_forwards_request_and_returns_backend_response() {
+    // Spin up a mock backend on a fixed port
+    let mock_port: u16 = 19998;
+    let mock_server = actix_web::HttpServer::new(|| {
+        actix_web::App::new().route(
+            "/api/hello",
+            web::get().to(|| async { HttpResponse::Ok().body("hello from backend") }),
+        )
+    })
+    .bind(format!("127.0.0.1:{mock_port}"))
+    .unwrap();
+
+    let server = mock_server.run();
+    let handle = tokio::spawn(server);
+
+    // Brief yield to let the server start accepting connections
+    tokio::task::yield_now().await;
+
+    let config = make_config(mock_port);
+    let client = reqwest::Client::new();
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(client))
+            .app_data(web::Data::new(config))
+            .service(web::scope("/api").default_service(web::to(proxy_handler))),
+    )
+    .await;
+
+    let req = test::TestRequest::get().uri("/api/hello").to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body = test::read_body(resp).await;
+    assert_eq!(body, "hello from backend");
+
+    handle.abort();
+}

--- a/tests/release.rs
+++ b/tests/release.rs
@@ -1,0 +1,24 @@
+// tests/release.rs
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::str::contains;
+use tempfile::tempdir;
+
+#[test]
+fn release_command_fails_without_flux_toml() {
+    let dir = tempdir().unwrap();
+    cargo_bin_cmd!("flux-wasm-builder")
+        .args(["release"])
+        .current_dir(dir.path())
+        .assert()
+        .failure();
+}
+
+#[test]
+fn release_command_exists_in_help() {
+    cargo_bin_cmd!("flux-wasm-builder")
+        .args(["--help"])
+        .assert()
+        .success()
+        .stdout(contains("release"));
+}

--- a/tests/scss.rs
+++ b/tests/scss.rs
@@ -1,0 +1,35 @@
+// tests/scss.rs
+
+use flux_wasm_builder::build::scss::{ScssError, compile_scss};
+use tempfile::tempdir;
+
+#[test]
+fn compile_scss_with_variables() {
+    let dir = tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("screen.scss"),
+        "$primary: #333; body { color: $primary; }",
+    )
+    .unwrap();
+    let result = compile_scss(dir.path()).unwrap();
+    let css = std::str::from_utf8(&result).unwrap();
+    assert!(css.contains("#333") || css.contains("333"), "SCSS variable should be resolved");
+}
+
+#[test]
+fn compile_scss_with_imports() {
+    let dir = tempdir().unwrap();
+    std::fs::write(dir.path().join("_base.scss"), "* { box-sizing: border-box; }").unwrap();
+    std::fs::write(dir.path().join("screen.scss"), "@use 'base';").unwrap();
+    let result = compile_scss(dir.path());
+    // Should compile without error
+    assert!(result.is_ok(), "SCSS with @use should compile successfully");
+}
+
+#[test]
+fn compile_scss_returns_compile_failed_error_variant() {
+    let dir = tempdir().unwrap();
+    std::fs::write(dir.path().join("screen.scss"), "$x: ;").unwrap(); // invalid
+    let result = compile_scss(dir.path());
+    assert!(matches!(result, Err(ScssError::CompileFailed(_))));
+}

--- a/tests/styles.rs
+++ b/tests/styles.rs
@@ -1,0 +1,64 @@
+// tests/styles.rs
+
+use actix_web::{App, test, web};
+use flux_wasm_builder::dev::styles::styles_handler;
+use std::sync::{Arc, RwLock};
+
+#[actix_web::test]
+async fn styles_handler_returns_200_with_css_content_type() {
+    let css = Arc::new(RwLock::new(b"body { color: red; }".to_vec()));
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(css))
+            .route("/styles/screen.css", web::get().to(styles_handler)),
+    )
+    .await;
+
+    let req = test::TestRequest::get().uri("/styles/screen.css").to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let ct = resp.headers().get("content-type").unwrap().to_str().unwrap();
+    assert!(ct.contains("text/css"), "content-type should be text/css, got {ct}");
+}
+
+#[actix_web::test]
+async fn styles_handler_returns_correct_bytes() {
+    let expected = b"h1 { font-size: 2rem; }".to_vec();
+    let css = Arc::new(RwLock::new(expected.clone()));
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(css))
+            .route("/styles/screen.css", web::get().to(styles_handler)),
+    )
+    .await;
+
+    let req = test::TestRequest::get().uri("/styles/screen.css").to_request();
+    let body = test::read_body(test::call_service(&app, req).await).await;
+
+    assert_eq!(body.as_ref(), expected.as_slice());
+}
+
+#[actix_web::test]
+async fn styles_handler_reflects_updated_css() {
+    let css = Arc::new(RwLock::new(b"body {}".to_vec()));
+    let css_writer = css.clone();
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(css))
+            .route("/styles/screen.css", web::get().to(styles_handler)),
+    )
+    .await;
+
+    // Update the CSS in the shared state
+    *css_writer.write().unwrap() = b"body { background: blue; }".to_vec();
+
+    let req = test::TestRequest::get().uri("/styles/screen.css").to_request();
+    let body = test::read_body(test::call_service(&app, req).await).await;
+
+    assert!(
+        std::str::from_utf8(&body).unwrap().contains("blue"),
+        "handler should reflect updated CSS bytes"
+    );
+}


### PR DESCRIPTION
- Fix stale test: rename init_prints_cargo_backend_next_step to init_prints_flux_wasm_builder_dev_next_step and update expected output string from "cargo backend" to "flux-wasm-builder dev"

- Add scaffolding tests to tests/init.rs: assert that init creates frontend/styles/screen.scss, backend/src/static_assets.rs, that screen.scss is non-empty with CSS reset content, that static_assets.rs has embed-assets cfg gate with required handlers, that index.html links /styles/screen.css, and that .gitignore excludes compiled screen.css

- Add 5 unit tests to src/build/scss.rs covering: non-empty output, valid UTF-8 output, SCSS nesting expansion, missing file error, and invalid SCSS error variant

- Create tests/scss.rs with 3 integration tests for compile_scss: variable resolution, @use imports, and CompileFailed error variant

- Create tests/styles.rs with 3 actix-web handler tests for styles_handler: 200 + text/css content-type, correct bytes, and reflection of updated shared CSS state

- Create tests/proxy.rs with 2 actix-web tests for proxy_handler: 502 when backend unreachable, and forwarding to a real mock backend

- Create tests/release.rs with 2 smoke tests: failure without flux.toml and presence of "release" in --help output

- Fix 2 pre-existing clippy warnings: use std::io::Error::other() in dev/mod.rs and remove unnecessary borrow in release/mod.rs

https://claude.ai/code/session_01EZnSja5hFQiXRkXq4S44Dw