### PR TITLE
Fix build coordinator clearing pending flag on build failure

### DIFF
--- a/src/build/build_coordinator.rs
+++ b/src/build/build_coordinator.rs
@@ -100,7 +100,6 @@ pub async fn run_build_loop<F, Fut>(
             Err(ref e) => {
                 // Build failure is NOT fatal to the loop — continue watching
                 tracing::warn!(parent: &span, error = %e, "rebuild failed — previous assets still served");
-                pending = false;
             }
         }
 


### PR DESCRIPTION
When a build failed, the error branch unconditionally set pending=false, discarding any queued build trigger. This meant a second file-change signal that arrived while the first (failing) build was running would be silently dropped, blocking all subsequent builds until the next file change.

Remove the pending=false from the error branch so that queued triggers survive build failures, consistent with the documented behaviour that failures are not fatal to the loop.

https://claude.ai/code/session_01EZnSja5hFQiXRkXq4S44Dw