### PR TITLE
Add public directory support for serving static assets

### DIFF
--- a/src/build/static_assets.rs
+++ b/src/build/static_assets.rs
@@ -12,7 +12,7 @@
 //! In release mode (with `embed-assets` feature), assets are embedded
 //! directly into the binary at compile time using `include_dir`.
 
-use actix_web::{HttpResponse, Responder, web};
+use actix_web::{HttpRequest, HttpResponse, Responder, web};
 
 use super::DevMode;
 use super::wasm_pack::BuildConfig;
@@ -145,6 +145,8 @@ pub async fn serve_pkg_file(
 /// This enables client-side routing in the Yew frontend.
 /// Any route not matched by API or static asset handlers will receive index.html.
 ///
+/// If the request path matches a file in `public/`, that file is served instead.
+///
 /// In development mode (`DevMode(true)`), the reload script is injected
 /// into the HTML before serving to enable live reload.
 ///
@@ -152,12 +154,42 @@ pub async fn serve_pkg_file(
 /// Reads index.html from the filesystem and injects reload script.
 #[cfg(not(feature = "embed-assets"))]
 pub async fn spa_fallback(
+    req: HttpRequest,
     config: web::Data<BuildConfig>,
     dev_mode: web::Data<DevMode>,
 ) -> impl Responder {
     let span = tracing::debug_span!("spa_fallback");
     let _enter = span.enter();
 
+    // Check if the path matches a file in public/
+    let req_path = req.path().trim_start_matches('/');
+    if !req_path.is_empty() {
+        let safe_name = match std::path::Path::new(req_path).file_name() {
+            Some(n) => n.to_owned(),
+            None => {
+                tracing::warn!(path = %req_path, "path traversal attempt blocked in public/");
+                return HttpResponse::BadRequest().finish();
+            }
+        };
+        let public_file = config.public_path.join(&safe_name);
+        if public_file.exists() {
+            match tokio::fs::read(&public_file).await {
+                Ok(bytes) => {
+                    let mime = mime_guess::from_path(&safe_name).first_or_octet_stream();
+                    tracing::debug!(path = %public_file.display(), "serving public file");
+                    return HttpResponse::Ok()
+                        .content_type(mime.to_string())
+                        .body(bytes);
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "failed to read public file");
+                    return HttpResponse::InternalServerError().finish();
+                }
+            }
+        }
+    }
+
+    // Fall through to index.html
     match tokio::fs::read(&config.index_html_path).await {
         Ok(bytes) => {
             tracing::debug!(path = %config.index_html_path.display(), "serving index.html");
@@ -193,6 +225,7 @@ pub async fn spa_fallback(
 /// No reload script is injected.
 #[cfg(feature = "embed-assets")]
 pub async fn spa_fallback(
+    _req: HttpRequest,
     _config: web::Data<BuildConfig>,
     _dev_mode: web::Data<DevMode>,
 ) -> impl Responder {
@@ -308,15 +341,18 @@ mod tests {
         let dir = tempdir().unwrap();
         let index = dir.path().join("index.html");
         std::fs::write(&index, b"<html></html>").unwrap();
+        let public = dir.path().join("public");
+        std::fs::create_dir(&public).unwrap();
         let config = BuildConfig {
             index_html_path: index,
+            public_path: public,
             ..BuildConfig::new("/unused")
         };
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(config))
                 .app_data(web::Data::new(DevMode(false)))
-                .default_service(web::get().to(spa_fallback)),
+                .default_service(web::to(spa_fallback)),
         )
         .await;
         let req = test::TestRequest::get()
@@ -337,8 +373,11 @@ mod tests {
     async fn api_route_takes_precedence_over_spa_fallback() {
         let dir = tempdir().unwrap();
         std::fs::write(dir.path().join("index.html"), b"<html></html>").unwrap();
+        let public = dir.path().join("public");
+        std::fs::create_dir(&public).unwrap();
         let config = BuildConfig {
             index_html_path: dir.path().join("index.html"),
+            public_path: public,
             ..BuildConfig::new("/unused")
         };
         async fn hello() -> impl actix_web::Responder {
@@ -349,7 +388,7 @@ mod tests {
                 .app_data(web::Data::new(config))
                 .app_data(web::Data::new(DevMode(false)))
                 .route("/api/hello", web::get().to(hello))
-                .default_service(web::get().to(spa_fallback)),
+                .default_service(web::to(spa_fallback)),
         )
         .await;
         let req = test::TestRequest::get().uri("/api/hello").to_request();
@@ -371,15 +410,18 @@ mod tests {
         let dir = tempdir().unwrap();
         let index = dir.path().join("index.html");
         std::fs::write(&index, b"<html><body></body></html>").unwrap();
+        let public = dir.path().join("public");
+        std::fs::create_dir(&public).unwrap();
         let config = BuildConfig {
             index_html_path: index,
+            public_path: public,
             ..BuildConfig::new("/unused")
         };
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(config))
                 .app_data(web::Data::new(DevMode(true)))
-                .default_service(web::get().to(spa_fallback)),
+                .default_service(web::to(spa_fallback)),
         )
         .await;
         let body = test::read_body(
@@ -397,15 +439,18 @@ mod tests {
         let dir = tempdir().unwrap();
         let index = dir.path().join("index.html");
         std::fs::write(&index, b"<html><body></body></html>").unwrap();
+        let public = dir.path().join("public");
+        std::fs::create_dir(&public).unwrap();
         let config = BuildConfig {
             index_html_path: index,
+            public_path: public,
             ..BuildConfig::new("/unused")
         };
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(config))
                 .app_data(web::Data::new(DevMode(false)))
-                .default_service(web::get().to(spa_fallback)),
+                .default_service(web::to(spa_fallback)),
         )
         .await;
         let body = test::read_body(
@@ -416,6 +461,106 @@ mod tests {
             !std::str::from_utf8(&body).unwrap().contains("/ws/reload"),
             "index.html should not contain reload script in release mode"
         );
+    }
+
+    #[actix_web::test]
+    async fn serves_file_from_public_directory() {
+        let dir = tempdir().unwrap();
+        let public = dir.path().join("public");
+        std::fs::create_dir(&public).unwrap();
+        std::fs::write(public.join("favicon.ico"), b"fake ico").unwrap();
+        std::fs::write(dir.path().join("index.html"), b"<html></html>").unwrap();
+        let config = BuildConfig {
+            public_path: public,
+            index_html_path: dir.path().join("index.html"),
+            ..BuildConfig::new("/unused")
+        };
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(config))
+                .app_data(web::Data::new(DevMode(false)))
+                .default_service(web::to(spa_fallback)),
+        )
+        .await;
+        let req = test::TestRequest::get().uri("/favicon.ico").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 200);
+        let body = test::read_body(resp).await;
+        assert_eq!(body.as_ref(), b"fake ico");
+    }
+
+    #[actix_web::test]
+    async fn public_file_takes_precedence_over_spa_fallback() {
+        let dir = tempdir().unwrap();
+        let public = dir.path().join("public");
+        std::fs::create_dir(&public).unwrap();
+        std::fs::write(public.join("robots.txt"), b"User-agent: *").unwrap();
+        std::fs::write(dir.path().join("index.html"), b"<html></html>").unwrap();
+        let config = BuildConfig {
+            public_path: public,
+            index_html_path: dir.path().join("index.html"),
+            ..BuildConfig::new("/unused")
+        };
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(config))
+                .app_data(web::Data::new(DevMode(false)))
+                .default_service(web::to(spa_fallback)),
+        )
+        .await;
+        let req = test::TestRequest::get().uri("/robots.txt").to_request();
+        let resp = test::call_service(&app, req).await;
+        let ct = resp.headers().get("content-type").unwrap().to_str().unwrap();
+        assert!(!ct.contains("text/html"), "robots.txt should not return index.html");
+    }
+
+    #[actix_web::test]
+    async fn unknown_path_falls_through_to_index_html() {
+        let dir = tempdir().unwrap();
+        let public = dir.path().join("public");
+        std::fs::create_dir(&public).unwrap();
+        std::fs::write(dir.path().join("index.html"), b"<html></html>").unwrap();
+        let config = BuildConfig {
+            public_path: public,
+            index_html_path: dir.path().join("index.html"),
+            ..BuildConfig::new("/unused")
+        };
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(config))
+                .app_data(web::Data::new(DevMode(false)))
+                .default_service(web::to(spa_fallback)),
+        )
+        .await;
+        let req = test::TestRequest::get().uri("/some/spa/route").to_request();
+        let resp = test::call_service(&app, req).await;
+        let ct = resp.headers().get("content-type").unwrap().to_str().unwrap();
+        assert!(ct.contains("text/html"), "SPA route should return index.html");
+    }
+
+    #[actix_web::test]
+    async fn serves_public_file_with_correct_mime_type() {
+        let dir = tempdir().unwrap();
+        let public = dir.path().join("public");
+        std::fs::create_dir(&public).unwrap();
+        std::fs::write(public.join("logo.png"), b"\x89PNG").unwrap();
+        std::fs::write(dir.path().join("index.html"), b"<html></html>").unwrap();
+        let config = BuildConfig {
+            public_path: public,
+            index_html_path: dir.path().join("index.html"),
+            ..BuildConfig::new("/unused")
+        };
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(config))
+                .app_data(web::Data::new(DevMode(false)))
+                .default_service(web::to(spa_fallback)),
+        )
+        .await;
+        let req = test::TestRequest::get().uri("/logo.png").to_request();
+        let resp = test::call_service(&app, req).await;
+        let ct = resp.headers().get("content-type").unwrap().to_str().unwrap();
+        assert!(ct.contains("image/png"), "png should have image/png content-type, got {ct}");
     }
 }
 

--- a/src/build/wasm_pack.rs
+++ b/src/build/wasm_pack.rs
@@ -41,6 +41,8 @@ pub struct BuildConfig {
     pub pkg_output_path: PathBuf,
     /// Path to index.html (default: frontend_crate_path + "/index.html")
     pub index_html_path: PathBuf,
+    /// Path to the public/ directory (default: frontend_crate_path + "/public")
+    pub public_path: PathBuf,
     /// Watch debounce interval in milliseconds (default: 300)
     pub watch_debounce_ms: u64,
     /// WebSocket path for reload signaling (default: "/ws/reload")
@@ -59,6 +61,7 @@ impl BuildConfig {
         Self {
             pkg_output_path: frontend_crate_path.join("pkg"),
             index_html_path: frontend_crate_path.join("index.html"),
+            public_path: frontend_crate_path.join("public"),
             watch_debounce_ms: 300,
             reload_ws_path: "/ws/reload".to_string(),
             port: 8080,
@@ -173,6 +176,12 @@ pub async fn run_command_with_timeout(
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn build_config_default_public_path_is_relative_to_frontend() {
+        let config = BuildConfig::new(PathBuf::from("../frontend"));
+        assert_eq!(config.public_path, PathBuf::from("../frontend/public"));
+    }
 
     #[test]
     fn build_config_default_pkg_path_is_relative_to_frontend() {

--- a/src/build/watcher.rs
+++ b/src/build/watcher.rs
@@ -62,18 +62,25 @@ pub fn start_watcher(
 
     tracing::info!("starting file watcher");
 
+    // For Rust source directories, only trigger on .rs changes.
+    // For other directories (e.g. public/), trigger on any file change.
+    let is_src_dir = watch_path.ends_with("src");
+
     let mut debouncer = new_debouncer(
         Duration::from_millis(debounce_ms),
         move |result: DebounceEventResult| {
             match result {
                 Ok(events) => {
-                    // Check if any event involves a .rs file
-                    let rs_change = events
-                        .iter()
-                        .any(|e| e.path.extension().map(|ext| ext == "rs").unwrap_or(false));
+                    let should_trigger = if is_src_dir {
+                        events
+                            .iter()
+                            .any(|e| e.path.extension().map(|ext| ext == "rs").unwrap_or(false))
+                    } else {
+                        !events.is_empty()
+                    };
 
-                    if rs_change {
-                        tracing::debug!(event_count = events.len(), "Rust source change detected");
+                    if should_trigger {
+                        tracing::debug!(event_count = events.len(), "file change detected");
                         // Use blocking_send() because this callback runs on a non-async
                         // background thread (notify's thread pool), but the receiver is
                         // a tokio async channel.
@@ -151,7 +158,8 @@ mod tests {
         std::fs::create_dir(&src).unwrap();
 
         let (tx, mut rx) = mpsc::channel(8);
-        let _watcher = start_watcher(dir.path(), 50, tx).expect("watcher should start");
+        // Watch the `src` subdirectory so is_src_dir = true (only .rs files trigger)
+        let _watcher = start_watcher(&src, 50, tx).expect("watcher should start");
 
         // Wait for watcher to initialize
         std::thread::sleep(Duration::from_millis(200));
@@ -182,7 +190,7 @@ mod tests {
 
         let (tx, mut rx) = mpsc::channel(8);
 
-        let watcher = start_watcher(dir.path(), 50, tx).expect("watcher should start");
+        let watcher = start_watcher(&src, 50, tx).expect("watcher should start");
 
         // Wait for watcher to initialize
         std::thread::sleep(Duration::from_millis(200));
@@ -226,7 +234,7 @@ mod tests {
         std::fs::write(src.join("lib.rs"), b"// initial").unwrap();
 
         let (tx, mut rx) = mpsc::channel(8);
-        let _watcher = start_watcher(dir.path(), 100, tx).expect("watcher should start");
+        let _watcher = start_watcher(&src, 100, tx).expect("watcher should start");
 
         // Wait for watcher to initialize
         std::thread::sleep(Duration::from_millis(200));

--- a/src/dev/mod.rs
+++ b/src/dev/mod.rs
@@ -54,6 +54,21 @@ pub async fn run() -> Result<(), DevError> {
         restart_tx,
     )?;
 
+    let (public_tx, mut public_rx) = tokio::sync::mpsc::channel::<()>(8);
+    let public_watch_path = std::env::current_dir()?.join("frontend/public");
+    let _public_watcher = start_watcher(
+        &public_watch_path,
+        config.dev.watch_debounce_ms,
+        public_tx,
+    )?;
+
+    let reload_tx_for_public = reload_tx.clone();
+    tokio::spawn(async move {
+        while let Some(()) = public_rx.recv().await {
+            let _ = reload_tx_for_public.send(());
+        }
+    });
+
     let reload_tx_clone = reload_tx.clone();
     let build_config = BuildConfig::new(std::env::current_dir()?.join("frontend"));
     println!("Building frontend...");

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -90,6 +90,7 @@ fn create_dirs(project_root: &Path) -> Result<(), InitError> {
         project_root.join("backend/src/api"),
         project_root.join("frontend/src"),
         project_root.join("frontend/styles"),
+        project_root.join("frontend/public"),
         project_root.join("shared/src"),
     ];
 
@@ -159,6 +160,10 @@ fn write_files(project_root: &Path, name: &str) -> Result<(), InitError> {
         (
             project_root.join("frontend/styles/screen.scss"),
             templates::frontend_screen_scss().to_string(),
+        ),
+        (
+            project_root.join("frontend/public/.gitkeep"),
+            templates::frontend_public_gitkeep().to_string(),
         ),
         // Shared
         (

--- a/src/init/templates.rs
+++ b/src/init/templates.rs
@@ -96,6 +96,15 @@ pub fn frontend_screen_scss() -> &'static str {
 }
 
 // =============================================================================
+// Frontend Public Templates
+// =============================================================================
+
+/// Empty .gitkeep for frontend/public/ so the directory is tracked by git
+pub fn frontend_public_gitkeep() -> &'static str {
+    ""
+}
+
+// =============================================================================
 // Shared Templates
 // =============================================================================
 

--- a/src/init/templates/backend/build.rs
+++ b/src/init/templates/backend/build.rs
@@ -18,5 +18,13 @@ fn main() {
                  flux-wasm-builder release\n\n"
             );
         }
+
+        let public = std::path::Path::new("../frontend/public");
+        if !public.exists() {
+            panic!(
+                "\n\nembedding assets requires frontend/public/ to exist.\n\
+                 Create it first, even if empty.\n\n"
+            );
+        }
     }
 }

--- a/src/init/templates/backend/src/static_assets.rs
+++ b/src/init/templates/backend/src/static_assets.rs
@@ -16,6 +16,10 @@ static EMBEDDED_CSS: &[u8] = include_bytes!(
 );
 
 #[cfg(feature = "embed-assets")]
+static EMBEDDED_PUBLIC: include_dir::Dir =
+    include_dir::include_dir!("$CARGO_MANIFEST_DIR/../frontend/public");
+
+#[cfg(feature = "embed-assets")]
 pub async fn serve_pkg_file(path: web::Path<String>) -> impl Responder {
     let filename = path.into_inner();
     let safe_name = match std::path::Path::new(&filename).file_name() {
@@ -41,7 +45,21 @@ pub async fn serve_css() -> impl Responder {
 }
 
 #[cfg(feature = "embed-assets")]
-pub async fn spa_fallback() -> impl Responder {
+pub async fn spa_fallback(req: actix_web::HttpRequest) -> impl Responder {
+    let req_path = req.path().trim_start_matches('/');
+    if !req_path.is_empty() {
+        let safe_name = match std::path::Path::new(req_path).file_name() {
+            Some(n) => n.to_owned(),
+            None => return HttpResponse::BadRequest().finish(),
+        };
+        if let Some(file) = EMBEDDED_PUBLIC.get_file(&safe_name) {
+            let mime = mime_guess::from_path(&safe_name).first_or_octet_stream();
+            return HttpResponse::Ok()
+                .content_type(mime.to_string())
+                .body(file.contents().to_vec());
+        }
+    }
+
     HttpResponse::Ok()
         .content_type("text/html; charset=utf-8")
         .body(EMBEDDED_INDEX.to_vec())

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -148,6 +148,30 @@ fn init_gitignore_excludes_compiled_css() {
 }
 
 #[test]
+fn init_creates_public_directory() {
+    let dir = tempdir().unwrap();
+    cargo_bin_cmd!("flux-wasm-builder")
+        .args(["init", "test-app"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    assert!(dir.path().join("test-app/frontend/public").exists());
+}
+
+#[test]
+fn init_public_directory_contains_gitkeep() {
+    let dir = tempdir().unwrap();
+    cargo_bin_cmd!("flux-wasm-builder")
+        .args(["init", "test-app"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    assert!(dir.path().join("test-app/frontend/public/.gitkeep").exists());
+}
+
+#[test]
 fn dev_command_exists() {
     let dir = tempdir().unwrap();
     cargo_bin_cmd!("flux-wasm-builder")

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -113,15 +113,18 @@ async fn index_html_contains_reload_script_when_dev_mode_true() {
     let dir = tempdir().unwrap();
     let index = dir.path().join("index.html");
     std::fs::write(&index, b"<html><body></body></html>").unwrap();
+    let public = dir.path().join("public");
+    std::fs::create_dir(&public).unwrap();
     let config = BuildConfig {
         index_html_path: index,
+        public_path: public,
         ..BuildConfig::new("/unused")
     };
     let app = actix_test::init_service(
         App::new()
             .app_data(web::Data::new(config))
             .app_data(web::Data::new(DevMode(true)))
-            .default_service(web::get().to(spa_fallback)),
+            .default_service(web::to(spa_fallback)),
     )
     .await;
     let body = actix_test::read_body(
@@ -139,15 +142,18 @@ async fn index_html_omits_reload_script_when_dev_mode_false() {
     let dir = tempdir().unwrap();
     let index = dir.path().join("index.html");
     std::fs::write(&index, b"<html><body></body></html>").unwrap();
+    let public = dir.path().join("public");
+    std::fs::create_dir(&public).unwrap();
     let config = BuildConfig {
         index_html_path: index,
+        public_path: public,
         ..BuildConfig::new("/unused")
     };
     let app = actix_test::init_service(
         App::new()
             .app_data(web::Data::new(config))
             .app_data(web::Data::new(DevMode(false)))
-            .default_service(web::get().to(spa_fallback)),
+            .default_service(web::to(spa_fallback)),
     )
     .await;
     let body = actix_test::read_body(


### PR DESCRIPTION
## Summary
This PR adds support for serving static assets from a `frontend/public/` directory, enabling applications to serve files like `favicon.ico`, `robots.txt`, and other public assets alongside the SPA fallback routing.

## Key Changes

- **Static Asset Serving**: Modified `spa_fallback()` to check for and serve files from `public/` before falling back to `index.html`
  - Implements path traversal protection by extracting only the filename
  - Automatically detects MIME types using `mime_guess`
  - Handles file read errors gracefully with appropriate HTTP responses

- **File Watcher Enhancement**: Updated the file watcher to trigger rebuilds on any file change in non-src directories (like `public/`), while maintaining `.rs`-only filtering for `src/`

- **Project Initialization**: 
  - `init` command now creates `frontend/public/` directory with `.gitkeep` file
  - Updated build.rs to validate public directory exists when embedding assets

- **Configuration**: Added `public_path` field to `BuildConfig` struct with sensible defaults

- **Embedded Assets Support**: Template backend now includes embedded public files and serves them with correct MIME types

- **Test Coverage**: Added comprehensive tests for:
  - Serving files from public directory
  - Public files taking precedence over SPA fallback
  - Unknown routes falling through to index.html
  - Correct MIME type detection for public files

## Implementation Details

- Path traversal attacks are prevented by using `Path::file_name()` which strips directory components
- File serving in dev mode reads from filesystem; in release mode with `embed-assets` feature, files are embedded at compile time
- The watcher distinguishes between `src/` directories (`.rs` files only) and other directories (any file change) to optimize rebuild triggers
- Public file checks happen before index.html fallback, ensuring static assets are served with correct content types

https://claude.ai/code/session_01NPW1SRV8mJrwBdQKnVtnBi