### PR TITLE
Fix backend process spawning with correct working directory

### DIFF
--- a/src/dev/mod.rs
+++ b/src/dev/mod.rs
@@ -105,9 +105,11 @@ struct ProcessManager {
 
 impl ProcessManager {
     fn new(config: &FluxConfig) -> Result<Self, DevError> {
+        let backend_dir = std::env::current_dir()?.join("backend");
         let child = Command::new("cargo")
             .args(["run", "-p", &format!("{}-backend", config.project.name)])
             .env("FLUX_BACKEND_PORT", config.dev.backend_port.to_string())
+            .current_dir(backend_dir)
             .spawn()?;
 
         Ok(Self {
@@ -149,8 +151,11 @@ impl ProcessManager {
         }
 
         // Respawn
+        let backend_dir = std::env::current_dir()?.join("backend");
         let child = Command::new("cargo")
             .args(["run", "-p", &format!("{}-backend", config.project.name)])
+            .env("FLUX_BACKEND_PORT", config.dev.backend_port.to_string())
+            .current_dir(backend_dir)
             .spawn()?;
 
         self.handle = Some(child);


### PR DESCRIPTION
## Summary
Fixed the backend process spawning logic to execute cargo commands from the correct working directory and ensure consistent environment configuration across process lifecycle.

## Key Changes
- Set the backend process working directory to `backend/` subdirectory when spawning cargo commands
- Added missing `FLUX_BACKEND_PORT` environment variable in the process respawn logic to match initial spawn configuration
- Applied working directory and environment consistency to both initial process creation and respawn scenarios

## Implementation Details
The changes ensure that:
1. Cargo commands are executed from the `backend/` directory context, which is necessary for proper workspace resolution
2. The backend port environment variable is consistently set whenever the backend process is spawned or respawned
3. Both the `new()` initialization and the respawn logic in the process manager follow the same configuration pattern

https://claude.ai/code/session_018ipq5pdELN3yERZ43rvkxb