### PR TITLE
Make file watcher extension filtering configurable

### DIFF
--- a/src/build/watcher.rs
+++ b/src/build/watcher.rs
@@ -45,13 +45,14 @@ pub type FileWatcher =
 ///
 /// ```ignore
 /// let (tx, rx) = tokio::sync::mpsc::channel(8);
-/// let watcher = start_watcher(Path::new("../frontend/src"), 300, tx)?;
+/// let watcher = start_watcher(Path::new("../frontend/src"), 300, tx, Some(&["rs"]))?;
 /// // Store `watcher` in a long-lived struct - do not drop it!
 /// ```
 pub fn start_watcher(
     watch_path: &Path,
     debounce_ms: u64,
     build_tx: Sender<()>,
+    extensions: Option<&'static [&'static str]>,
 ) -> Result<FileWatcher, notify_debouncer_mini::notify::Error> {
     let span = tracing::info_span!(
         "file_watcher",
@@ -62,40 +63,38 @@ pub fn start_watcher(
 
     tracing::info!("starting file watcher");
 
-    // For Rust source directories, only trigger on .rs changes.
-    // For other directories (e.g. public/), trigger on any file change.
-    let is_src_dir = watch_path.ends_with("src");
-
     let mut debouncer = new_debouncer(
         Duration::from_millis(debounce_ms),
         move |result: DebounceEventResult| {
             match result {
                 Ok(events) => {
-                    let should_trigger = if is_src_dir {
-                        events
-                            .iter()
-                            .any(|e| e.path.extension().map(|ext| ext == "rs").unwrap_or(false))
-                    } else {
-                        !events.is_empty()
+                    let should_trigger = match extensions {
+                        Some(exts) => events.iter().any(|e| {
+                            e.path
+                                .extension()
+                                .and_then(|ext| ext.to_str())
+                                .map(|ext| exts.contains(&ext))
+                                .unwrap_or(false)
+                        }),
+                        None => !events.is_empty(),
                     };
 
                     if should_trigger {
-                        tracing::debug!(event_count = events.len(), "file change detected");
-                        // Use blocking_send() because this callback runs on a non-async
-                        // background thread (notify's thread pool), but the receiver is
-                        // a tokio async channel.
+                        tracing::debug!(
+                            event_count = events.len(),
+                            "file change detected"
+                        );
                         if let Err(e) = build_tx.blocking_send(()) {
-                            // The receiver has been dropped — the build coordinator
-                            // has exited. Stop logging; the process is likely shutting down.
-                            tracing::debug!(error = %e, "build channel closed — watcher callback exiting");
+                            tracing::debug!(
+                                error = %e,
+                                "build channel closed — watcher callback exiting"
+                            );
                         }
                     } else {
-                        tracing::trace!("ignored non-.rs file event");
+                        tracing::trace!("ignored file event (extension not matched)");
                     }
                 }
                 Err(e) => {
-                    // Watcher errors are non-fatal — log and continue.
-                    // Common causes: race condition on file deletion during atomic save.
                     tracing::warn!(error = %e, "file watcher error");
                 }
             }
@@ -129,7 +128,8 @@ mod tests {
         std::fs::write(src.join("lib.rs"), b"// initial").unwrap();
 
         let (tx, mut rx) = mpsc::channel(8);
-        let _watcher = start_watcher(dir.path(), 50, tx).expect("watcher should start");
+        let _watcher = start_watcher(dir.path(), 50, tx, Some(&["rs"]))
+            .expect("watcher should start");
 
         // Wait for watcher to initialize
         std::thread::sleep(Duration::from_millis(200));
@@ -158,8 +158,8 @@ mod tests {
         std::fs::create_dir(&src).unwrap();
 
         let (tx, mut rx) = mpsc::channel(8);
-        // Watch the `src` subdirectory so is_src_dir = true (only .rs files trigger)
-        let _watcher = start_watcher(&src, 50, tx).expect("watcher should start");
+        let _watcher = start_watcher(dir.path(), 50, tx, Some(&["rs"]))
+            .expect("watcher should start");
 
         // Wait for watcher to initialize
         std::thread::sleep(Duration::from_millis(200));
@@ -190,7 +190,8 @@ mod tests {
 
         let (tx, mut rx) = mpsc::channel(8);
 
-        let watcher = start_watcher(&src, 50, tx).expect("watcher should start");
+        let watcher = start_watcher(&src, 50, tx, Some(&["rs"]))
+            .expect("watcher should start");
 
         // Wait for watcher to initialize
         std::thread::sleep(Duration::from_millis(200));
@@ -222,7 +223,12 @@ mod tests {
     #[test]
     fn watcher_returns_error_for_nonexistent_path() {
         let (tx, _rx) = mpsc::channel(8);
-        let result = start_watcher(Path::new("/nonexistent/path/that/does/not/exist"), 50, tx);
+        let result = start_watcher(
+            Path::new("/nonexistent/path/that/does/not/exist"),
+            50,
+            tx,
+            Some(&["rs"]),
+        );
         assert!(result.is_err(), "should return error for nonexistent path");
     }
 
@@ -234,7 +240,8 @@ mod tests {
         std::fs::write(src.join("lib.rs"), b"// initial").unwrap();
 
         let (tx, mut rx) = mpsc::channel(8);
-        let _watcher = start_watcher(&src, 100, tx).expect("watcher should start");
+        let _watcher = start_watcher(&src, 100, tx, Some(&["rs"]))
+            .expect("watcher should start");
 
         // Wait for watcher to initialize
         std::thread::sleep(Duration::from_millis(200));
@@ -259,6 +266,93 @@ mod tests {
         assert!(
             count <= 2,
             "rapid changes should be debounced, got {count} signals"
+        );
+    }
+
+    #[test]
+    fn scss_file_change_triggers_signal_when_watching_scss() {
+        let dir = tempdir().unwrap();
+        let styles = dir.path().join("styles");
+        std::fs::create_dir(&styles).unwrap();
+        std::fs::write(styles.join("screen.scss"), "body { color: red; }").unwrap();
+
+        let (tx, mut rx) = mpsc::channel(8);
+        let _watcher = start_watcher(dir.path(), 50, tx, Some(&["scss"]))
+            .expect("watcher should start");
+
+        std::thread::sleep(Duration::from_millis(200));
+
+        std::fs::write(styles.join("screen.scss"), "body { color: blue; }").unwrap();
+
+        let result = std::thread::spawn(move || {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(async {
+                tokio::time::timeout(Duration::from_secs(3), rx.recv()).await
+            })
+        })
+        .join()
+        .unwrap();
+
+        assert!(
+            result.is_ok() && result.unwrap().is_some(),
+            "should receive signal after .scss file change"
+        );
+    }
+
+    #[test]
+    fn rs_file_does_not_trigger_signal_when_watching_scss() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir(&src).unwrap();
+
+        let (tx, mut rx) = mpsc::channel(8);
+        let _watcher = start_watcher(dir.path(), 50, tx, Some(&["scss"]))
+            .expect("watcher should start");
+
+        std::thread::sleep(Duration::from_millis(200));
+
+        std::fs::write(src.join("lib.rs"), "// change").unwrap();
+
+        let result = std::thread::spawn(move || {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(async {
+                tokio::time::timeout(Duration::from_millis(600), rx.recv()).await
+            })
+        })
+        .join()
+        .unwrap();
+
+        assert!(
+            result.is_err(),
+            ".rs change should not trigger signal when watching .scss only"
+        );
+    }
+
+    #[test]
+    fn none_extensions_triggers_on_any_file_change() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("logo.png"), b"\x89PNG").unwrap();
+
+        let (tx, mut rx) = mpsc::channel(8);
+        let _watcher = start_watcher(dir.path(), 50, tx, None)
+            .expect("watcher should start");
+
+        std::thread::sleep(Duration::from_millis(200));
+
+        std::fs::write(dir.path().join("logo.png"), b"\x89PNG updated").unwrap();
+
+        let result = std::thread::spawn(move || {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(async {
+                tokio::time::timeout(Duration::from_secs(3), rx.recv()).await
+            })
+        })
+        .join()
+        .unwrap();
+
+        assert!(
+            result.is_ok() && result.unwrap().is_some(),
+            "should receive signal for any file change when extensions is None"
         );
     }
 }

--- a/src/dev/mod.rs
+++ b/src/dev/mod.rs
@@ -45,13 +45,19 @@ pub async fn run() -> Result<(), DevError> {
     let (restart_tx, mut restart_rx) = tokio::sync::mpsc::channel::<()>(8);
 
     let watch_path = std::env::current_dir()?.join("frontend/src");
-    let _frontend_watcher = start_watcher(&watch_path, config.dev.watch_debounce_ms, build_tx)?;
+    let _frontend_watcher = start_watcher(
+        &watch_path,
+        config.dev.watch_debounce_ms,
+        build_tx,
+        Some(&["rs"]),
+    )?;
 
     let backend_watch_path = std::env::current_dir()?.join("backend/src");
     let _backend_watcher = start_watcher(
         &backend_watch_path,
         config.dev.watch_debounce_ms,
         restart_tx,
+        Some(&["rs"]),
     )?;
 
     let (public_tx, mut public_rx) = tokio::sync::mpsc::channel::<()>(8);
@@ -60,6 +66,7 @@ pub async fn run() -> Result<(), DevError> {
         &public_watch_path,
         config.dev.watch_debounce_ms,
         public_tx,
+        None,
     )?;
 
     let reload_tx_for_public = reload_tx.clone();

--- a/tests/watcher.rs
+++ b/tests/watcher.rs
@@ -21,7 +21,8 @@ fn rs_file_change_triggers_build_signal() {
     std::fs::write(src.join("lib.rs"), b"// initial").unwrap();
 
     let (tx, mut rx) = mpsc::channel(8);
-    let _watcher = start_watcher(dir.path(), 50, tx).expect("watcher should start");
+    let _watcher = start_watcher(dir.path(), 50, tx, Some(&["rs"]))
+        .expect("watcher should start");
 
     // Wait for watcher to initialize
     std::thread::sleep(Duration::from_millis(200));
@@ -51,7 +52,8 @@ fn non_rs_file_does_not_trigger_build_signal() {
 
     let (tx, mut rx) = mpsc::channel(8);
     // Watch the `src` subdirectory so is_src_dir = true (only .rs files trigger)
-    let _watcher = start_watcher(&src, 50, tx).expect("watcher should start");
+    let _watcher = start_watcher(&src, 50, tx, Some(&["rs"]))
+        .expect("watcher should start");
 
     // Wait for watcher to initialize
     std::thread::sleep(Duration::from_millis(200));
@@ -83,7 +85,8 @@ fn dropping_watcher_stops_events() {
     let (tx, mut rx) = mpsc::channel(8);
 
     // Watch the `src` subdirectory so is_src_dir = true (only .rs files trigger)
-    let watcher = start_watcher(&src, 50, tx).expect("watcher should start");
+    let watcher = start_watcher(&src, 50, tx, Some(&["rs"]))
+        .expect("watcher should start");
 
     // Wait for watcher to initialize
     std::thread::sleep(Duration::from_millis(200));
@@ -249,7 +252,8 @@ async fn watcher_and_coordinator_integration() {
 
     // Start the watcher with the tokio sender
     // The watcher will use blocking_send() internally
-    let _watcher = start_watcher(dir.path(), 50, tx).expect("watcher should start");
+    let _watcher = start_watcher(dir.path(), 50, tx, Some(&["rs"]))
+        .expect("watcher should start");
 
     // Wait for watcher to initialize
     tokio::time::sleep(Duration::from_millis(200)).await;


### PR DESCRIPTION
## Summary
Refactored the file watcher to accept a configurable list of file extensions instead of hardcoding extension filtering logic based on directory names. This makes the watcher more flexible and reusable for different file types.

## Key Changes
- Added `extensions: Option<&'static [&'static str]>` parameter to `start_watcher()` function
  - `Some(&["ext1", "ext2"])` filters to only those extensions
  - `None` triggers on any file change
- Removed hardcoded `is_src_dir` logic that only watched `.rs` files in directories ending with "src"
- Updated extension matching to use `to_str()` for proper string comparison
- Updated all call sites to explicitly specify extensions:
  - Frontend and backend watchers: `Some(&["rs"])`
  - Public assets watcher: `None` (watch all files)
- Added three new test cases:
  - `scss_file_change_triggers_signal_when_watching_scss`: Verifies SCSS file filtering works
  - `rs_file_does_not_trigger_signal_when_watching_scss`: Verifies extension exclusion works
  - `none_extensions_triggers_on_any_file_change`: Verifies `None` triggers on any file

## Implementation Details
- The extension filtering now happens in the debouncer callback using a match expression
- Extensions are compared as strings after converting from `OsStr`
- The change maintains backward compatibility in behavior while improving flexibility
- All existing tests updated to pass the new required parameter

https://claude.ai/code/session_01UKsKh8VQ8C6FhAq629Fj38