### PR TITLE
Add hot-reload support for SCSS style changes

### DIFF
--- a/src/dev/mod.rs
+++ b/src/dev/mod.rs
@@ -76,6 +76,34 @@ pub async fn run() -> Result<(), DevError> {
         }
     });
 
+    let (styles_tx, mut styles_rx) = tokio::sync::mpsc::channel::<()>(8);
+    let styles_watch_path = std::env::current_dir()?.join("frontend/styles");
+    let _styles_watcher = start_watcher(
+        &styles_watch_path,
+        config.dev.watch_debounce_ms,
+        styles_tx,
+        Some(&["scss"]),
+    )?;
+
+    let reload_tx_for_styles = reload_tx.clone();
+    let css_bytes_for_styles = css_bytes.clone();
+    tokio::spawn(async move {
+        while let Some(()) = styles_rx.recv().await {
+            let styles_path = std::env::current_dir()
+                .expect("failed to get current dir")
+                .join("frontend/styles");
+            match compile_scss(&styles_path) {
+                Ok(new_css) => {
+                    *css_bytes_for_styles.write().unwrap() = new_css;
+                    let _ = reload_tx_for_styles.send(());
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "SCSS compilation failed — previous styles still served");
+                }
+            }
+        }
+    });
+
     let reload_tx_clone = reload_tx.clone();
     let build_config = BuildConfig::new(std::env::current_dir()?.join("frontend"));
     println!("Building frontend...");


### PR DESCRIPTION
## Summary
This change adds file watching and hot-reload functionality for SCSS stylesheets during development. When style files are modified, they are automatically recompiled and served without requiring a manual restart.

## Key Changes
- Added a new file watcher for the `frontend/styles` directory that monitors changes to `.scss` files
- Implemented an async task that listens for style file changes and triggers SCSS recompilation
- Integrated compiled CSS updates into the existing reload mechanism, allowing clients to receive updated styles in real-time
- Added error handling to gracefully log compilation failures while continuing to serve previously compiled styles

## Implementation Details
- Uses the existing `start_watcher` utility with a debounce delay from config
- Reuses the `reload_tx` channel to notify clients of style updates
- Stores compiled CSS in a shared `Arc<RwLock>` for thread-safe access
- Compilation errors are logged as warnings without interrupting the dev server

https://claude.ai/code/session_0137wC153qd1YM29UzfVwqQE