### PR TITLE
Add embed-assets feature for zero-dependency binary deployments

### DIFF
--- a/src/init/templates/backend/configuration/base.yaml
+++ b/src/init/templates/backend/configuration/base.yaml
@@ -1,3 +1,4 @@
 application:
   port: 3001
   host: 127.0.0.1
+  base_url: ""

--- a/src/init/templates/backend/src/configuration.rs
+++ b/src/init/templates/backend/src/configuration.rs
@@ -27,13 +27,18 @@ impl ApplicationSettings {
     }
 }
 
+/// Load configuration.
+///
+/// In development builds (no `embed-assets` feature), reads YAML files from
+/// the filesystem, walking up from the current directory to find them.
+///
+/// In release builds (`embed-assets` feature), `configuration/base.yaml` is
+/// embedded in the binary at compile time and used as the mandatory base.
+/// An environment-specific YAML file is still read from the filesystem if
+/// present next to the binary (using `required(false)`), allowing production
+/// deployments to customise settings without a recompile. Environment
+/// variables prefixed with `APP_` always override everything.
 pub fn get_configuration() -> Result<Settings, config::ConfigError> {
-    let base_path = find_configuration_dir().unwrap_or_else(|| {
-        std::env::current_dir().expect("Failed to determine current directory")
-    });
-
-    let configuration_directory = base_path.join("configuration");
-
     let environment: Environment = std::env::var("APP_ENVIRONMENT")
         .unwrap_or_else(|_| "local".into())
         .try_into()
@@ -41,26 +46,66 @@ pub fn get_configuration() -> Result<Settings, config::ConfigError> {
 
     let environment_filename = format!("{}.yaml", environment.as_str());
 
-    let settings = config::Config::builder()
-        .add_source(config::File::from(
-            configuration_directory.join("base.yaml"),
-        ))
-        .add_source(config::File::from(
-            configuration_directory.join(environment_filename),
-        ))
-        .add_source(
+    #[cfg(feature = "embed-assets")]
+    {
+        // Base config is embedded at compile time — binary works with zero
+        // filesystem dependencies out of the box.
+        let mut builder = config::Config::builder().add_source(config::File::from_str(
+            include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/configuration/base.yaml"
+            )),
+            config::FileFormat::Yaml,
+        ));
+
+        // If an environment-specific file exists alongside the binary (or
+        // anywhere in the walk-up chain), layer it on top.  `required(false)`
+        // means its absence is not an error.
+        if let Some(base_path) = find_configuration_dir() {
+            let env_file = base_path.join("configuration").join(&environment_filename);
+            builder = builder.add_source(config::File::from(env_file).required(false));
+        }
+
+        builder = builder.add_source(
             config::Environment::with_prefix("APP")
                 .prefix_separator("_")
                 .separator("__"),
-        )
-        .build()?;
+        );
 
-    settings.try_deserialize::<Settings>()
+        return builder.build()?.try_deserialize::<Settings>();
+    }
+
+    #[cfg(not(feature = "embed-assets"))]
+    {
+        let base_path = find_configuration_dir().unwrap_or_else(|| {
+            std::env::current_dir().expect("Failed to determine current directory")
+        });
+
+        let configuration_directory = base_path.join("configuration");
+
+        let settings = config::Config::builder()
+            .add_source(config::File::from(
+                configuration_directory.join("base.yaml"),
+            ))
+            .add_source(config::File::from(
+                configuration_directory.join(environment_filename),
+            ))
+            .add_source(
+                config::Environment::with_prefix("APP")
+                    .prefix_separator("_")
+                    .separator("__"),
+            )
+            .build()?;
+
+        settings.try_deserialize::<Settings>()
+    }
 }
 
 /// Walk up from the current directory looking for a `configuration/base.yaml`.
-/// This allows the backend to be launched from the workspace root (as
-/// `flux-wasm-builder dev` does) or from the backend crate directory directly.
+///
+/// In dev mode this allows the backend to be launched from the workspace root
+/// or from the backend crate directory directly.  In release mode it is used
+/// to discover an optional environment-specific override file.
 fn find_configuration_dir() -> Option<PathBuf> {
     let mut dir = std::env::current_dir().ok()?;
     loop {
@@ -110,13 +155,10 @@ mod tests {
 
     #[test]
     fn find_configuration_dir_returns_none_when_no_config_exists() {
-        // A fresh temp dir has no configuration/base.yaml
         let dir = tempdir().unwrap();
         unsafe {
             std::env::set_current_dir(dir.path()).unwrap();
         }
-        // Can't assert None directly since other tests may have config dirs
-        // above them, but we can assert it doesn't panic
         let _ = find_configuration_dir();
     }
 


### PR DESCRIPTION
## Summary
This PR adds support for embedding configuration files in the binary at compile time via a new `embed-assets` feature flag. This enables zero-filesystem-dependency deployments while maintaining flexibility for environment-specific overrides in production.

## Key Changes
- **Feature-gated configuration loading**: Added conditional compilation with `embed-assets` feature
  - When enabled: `configuration/base.yaml` is embedded at compile time using `include_str!()`, making the binary self-contained
  - When disabled: Original behavior of reading YAML files from the filesystem is preserved
  
- **Production override support**: Even with embedded base config, environment-specific YAML files can still be discovered and loaded from the filesystem (marked as `required(false)`) using the existing `find_configuration_dir()` walk-up logic

- **Improved documentation**: Added comprehensive doc comments explaining the dual-mode behavior and deployment scenarios

- **Configuration update**: Added `base_url: ""` field to `base.yaml` for application settings

## Implementation Details
- The `embed-assets` build uses `config::File::from_str()` with `include_str!()` macro to embed the base configuration
- Environment variables (prefixed with `APP_`) continue to override all file-based configuration in both modes
- The `find_configuration_dir()` function now serves dual purposes: locating config in dev mode and discovering optional overrides in release mode
- Cleaned up test comments for clarity

https://claude.ai/code/session_0167TuUCWi1Rb6eUg8Jn6KD3