### PR TITLE
Clarify configuration embedding and deployment in release builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ Open `http://localhost:8080`. Edits to frontend, backend, styles, or public asse
 flux-wasm-builder release
 ```
 
-This runs `wasm-pack build --release` on the frontend, then `cargo build --release --features embed-assets` on the backend. The result is a single self-contained binary with all frontend assets embedded — no external files required.
+This runs `wasm-pack build --release` on the frontend, then `cargo build --release --features embed-assets` on the backend. The result is a single self-contained binary — all frontend assets **and** `configuration/base.yaml` are compiled in, so the binary runs with zero filesystem dependencies.
+
+Deploy the binary alone. To customise settings without a recompile, place an environment-specific YAML file (e.g. `configuration/production.yaml`) next to the binary or anywhere in its walk-up path. It is loaded on top of the embedded base config when present. `APP_*` environment variables are always applied last and override everything.
 
 ## Configuration
 
@@ -143,7 +145,7 @@ The tool runs four file watchers simultaneously:
 
 The scaffolded backend is an opinionated Actix-web starter. Out of the box `backend/src/` contains:
 
-- **`configuration.rs`** — YAML-based configuration loading via the `config` crate. Supports environment-specific overrides (`configuration/base.yaml`, `local.yaml`, `production.yaml`). The `FLUX_BACKEND_PORT` env var overrides the configured port at runtime.
+- **`configuration.rs`** — YAML-based configuration loading via the `config` crate. In development builds, reads `configuration/base.yaml` and an environment-specific file from the filesystem. In release builds (`embed-assets` feature), `base.yaml` is compiled directly into the binary via `include_str!` — no config files required at runtime. An optional environment-specific file (e.g. `configuration/production.yaml`) placed next to the binary is still loaded when present. `APP_*` environment variables override everything. The `FLUX_BACKEND_PORT` env var overrides the configured port at runtime.
 - **`startup.rs`** — `Application` struct that wires up the Actix-web server, routes, and middleware.
 - **`error.rs`** — `ApiError` enum implementing Actix-web's `ResponseError` trait, mapping variants (`BadRequest`, `NotFound`, `Internal`) to HTTP status codes.
 - **`response.rs`** — `ApiResponse<T>` generic wrapper implementing the `Responder` trait, with `success()` and `error()` constructors for consistent JSON responses.
@@ -174,7 +176,7 @@ pub struct StatusResponse {
 
 | Flag | Effect |
 |------|--------|
-| `embed-assets` | Embeds `frontend/pkg/`, `frontend/index.html`, `frontend/public/`, and compiled CSS into the binary at compile time |
+| `embed-assets` | Embeds `frontend/pkg/`, `frontend/index.html`, `frontend/public/`, compiled CSS, **and `configuration/base.yaml`** into the binary at compile time. The resulting binary has zero runtime filesystem dependencies. |
 
 Used automatically by `flux-wasm-builder release`.
 


### PR DESCRIPTION
## Summary
Updated documentation to clarify how configuration is handled in release builds with the `embed-assets` feature, particularly emphasizing that `configuration/base.yaml` is compiled into the binary and that environment-specific overrides can be provided at runtime without recompilation.

## Changes
- **Release build behavior**: Clarified that `configuration/base.yaml` is embedded into the binary via `include_str!` in release builds, eliminating filesystem dependencies for the base configuration
- **Runtime configuration overrides**: Documented that environment-specific YAML files (e.g., `configuration/production.yaml`) can be placed next to the binary or in its walk-up path to override the embedded base config without recompilation
- **Environment variable precedence**: Clarified that `APP_*` environment variables always take precedence and override all file-based configuration
- **Deployment guidance**: Added explicit guidance that the binary can be deployed standalone with zero filesystem dependencies, with optional configuration files for customization
- **Feature flag documentation**: Updated `embed-assets` feature description to explicitly mention that `configuration/base.yaml` is embedded and that the resulting binary has zero runtime filesystem dependencies

## Implementation Details
The changes are purely documentation updates that reflect the existing configuration loading behavior:
- Development builds read configuration files from the filesystem
- Release builds with `embed-assets` compile `base.yaml` directly into the binary
- Optional environment-specific files are loaded on top of the base config when present
- Environment variables provide the final override layer

https://claude.ai/code/session_01GMtm46aXGqkAcY9bBiQmza