### PR TITLE
Increase backend startup timeout and fix formatting

### DIFF
--- a/src/dev/mod.rs
+++ b/src/dev/mod.rs
@@ -161,7 +161,7 @@ impl ProcessManager {
             config.dev.backend_port
         );
 
-        let max_attempts = 30;
+        let max_attempts = 120;
         let mut attempts = 0;
 
         loop {

--- a/src/init/templates/backend/src/startup.rs
+++ b/src/init/templates/backend/src/startup.rs
@@ -4,7 +4,7 @@ use crate::api;
 use crate::configuration::Settings;
 use actix_web::{App, HttpServer};
 use actix_web::dev::Server;
- #[cfg(feature = "embed-assets")]
+#[cfg(feature = "embed-assets")]
 use actix_web::web;
 use actix_web::web::Data;
 use std::net::TcpListener;


### PR DESCRIPTION
## Summary
This PR makes two minor adjustments to improve backend startup reliability and code formatting consistency.

## Key Changes
- **Increased startup timeout**: Extended `max_attempts` from 30 to 120 in the process manager's backend connection loop, allowing more time for the backend server to become ready during development
- **Fixed formatting**: Corrected indentation of the `#[cfg(feature = "embed-assets")]` attribute in the backend startup template to follow Rust style conventions

## Details
The timeout increase provides a 4x longer grace period for backend initialization, which can help prevent premature timeout failures in slower development environments or when the backend takes longer to start up. The formatting fix ensures the generated backend code adheres to standard Rust formatting guidelines.

https://claude.ai/code/session_01M6Y3yEujP6MhQKpGQQs5UK