### PR TITLE
Fix proxy_returns_502_when_backend_unreachable test hanging

### DIFF
--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -21,7 +21,11 @@ fn make_config(backend_port: u16) -> FluxConfig {
 async fn proxy_returns_502_when_backend_unreachable() {
     // Port 19999 should have nothing listening
     let config = make_config(19999);
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(2))
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
+        .unwrap();
 
     let app = test::init_service(
         App::new()


### PR DESCRIPTION
Add connect_timeout (2s) and timeout (3s) to the reqwest::Client used in the 502 test. Without these, the default client waits indefinitely for a TCP connection to an unreachable port, causing the test to hang.

https://claude.ai/code/session_01M6Y3yEujP6MhQKpGQQs5UK