### PR TITLE
Add build error overlay to dev server

### DIFF
--- a/src/build/build_coordinator.rs
+++ b/src/build/build_coordinator.rs
@@ -10,6 +10,7 @@ use std::future::Future;
 use tokio::sync::{broadcast, mpsc::Receiver};
 
 use super::wasm_pack::BuildError;
+use super::DevServerMessage;
 
 /// Run the build loop, serializing rebuild requests.
 ///
@@ -58,7 +59,7 @@ use super::wasm_pack::BuildError;
 /// ```
 pub async fn run_build_loop<F, Fut>(
     mut build_rx: Receiver<()>,
-    reload_tx: broadcast::Sender<()>,
+    reload_tx: broadcast::Sender<DevServerMessage>,
     build_fn: F,
 ) where
     F: Fn() -> Fut + Send + 'static,
@@ -95,11 +96,12 @@ pub async fn run_build_loop<F, Fut>(
                 // The `let _ =` is intentional: send returns Err when there
                 // are no active subscribers, which is expected when no browser
                 // tabs are open. This must not be treated as an error.
-                let _ = reload_tx.send(());
+                let _ = reload_tx.send(DevServerMessage::Reload);
             }
             Err(ref e) => {
                 // Build failure is NOT fatal to the loop — continue watching
                 tracing::warn!(parent: &span, error = %e, "rebuild failed — previous assets still served");
+                let _ = reload_tx.send(DevServerMessage::BuildError(e.to_string()));
             }
         }
 
@@ -120,7 +122,7 @@ mod tests {
     #[tokio::test]
     async fn single_trigger_causes_one_build() {
         let (tx, rx) = mpsc::channel(8);
-        let (reload_tx, _reload_rx) = broadcast::channel::<()>(16);
+        let (reload_tx, _reload_rx) = broadcast::channel::<DevServerMessage>(16);
         let count = Arc::new(Mutex::new(0u32));
         let c = count.clone();
 
@@ -142,7 +144,7 @@ mod tests {
     #[tokio::test]
     async fn rapid_triggers_collapse_to_at_most_two_builds() {
         let (tx, rx) = mpsc::channel(8);
-        let (reload_tx, _reload_rx) = broadcast::channel::<()>(16);
+        let (reload_tx, _reload_rx) = broadcast::channel::<DevServerMessage>(16);
         let count = Arc::new(Mutex::new(0u32));
         let c = count.clone();
 
@@ -171,7 +173,7 @@ mod tests {
     #[tokio::test]
     async fn build_failure_does_not_block_subsequent_builds() {
         let (tx, rx) = mpsc::channel(8);
-        let (reload_tx, _reload_rx) = broadcast::channel::<()>(16);
+        let (reload_tx, _reload_rx) = broadcast::channel::<DevServerMessage>(16);
         let count = Arc::new(Mutex::new(0u32));
         let first = Arc::new(Mutex::new(true));
         let c = count.clone();
@@ -209,7 +211,7 @@ mod tests {
     #[tokio::test]
     async fn closed_channel_exits_loop_cleanly() {
         let (tx, rx) = mpsc::channel::<()>(8);
-        let (reload_tx, _reload_rx) = broadcast::channel::<()>(16);
+        let (reload_tx, _reload_rx) = broadcast::channel::<DevServerMessage>(16);
         let count = Arc::new(Mutex::new(0u32));
         let c = count.clone();
 
@@ -234,7 +236,7 @@ mod tests {
     #[tokio::test]
     async fn builds_run_sequentially_not_concurrently() {
         let (tx, rx) = mpsc::channel(8);
-        let (reload_tx, _reload_rx) = broadcast::channel::<()>(16);
+        let (reload_tx, _reload_rx) = broadcast::channel::<DevServerMessage>(16);
         let concurrent_count = Arc::new(Mutex::new(0u32));
         let max_concurrent = Arc::new(Mutex::new(0u32));
         let cc = concurrent_count.clone();
@@ -285,7 +287,7 @@ mod tests {
     #[tokio::test]
     async fn pending_flag_triggers_immediate_rebuild() {
         let (tx, rx) = mpsc::channel(8);
-        let (reload_tx, _reload_rx) = broadcast::channel::<()>(16);
+        let (reload_tx, _reload_rx) = broadcast::channel::<DevServerMessage>(16);
         let build_times = Arc::new(Mutex::new(Vec::new()));
         let bt = build_times.clone();
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -44,6 +44,19 @@ pub use watcher::{FileWatcher, start_watcher};
 #[cfg(not(feature = "embed-assets"))]
 pub use reload::{RELOAD_SCRIPT, inject_reload_script, ws_reload_handler};
 
+/// Messages sent over the dev-server broadcast channel.
+///
+/// The channel carries typed messages so that the WebSocket handler can
+/// distinguish between a successful build (→ page reload) and a failed
+/// build (→ browser error overlay).
+#[derive(Clone, Debug)]
+pub enum DevServerMessage {
+    /// A build or asset change completed successfully — reload the page.
+    Reload,
+    /// A build failed — display the provided error message as an overlay.
+    BuildError(String),
+}
+
 /// Flag indicating whether the server is running in development mode.
 ///
 /// In dev mode:

--- a/src/build/reload.rs
+++ b/src/build/reload.rs
@@ -17,6 +17,8 @@ use actix_ws::Message;
 use futures_util::stream::StreamExt;
 use tokio::sync::broadcast;
 
+use super::DevServerMessage;
+
 /// JavaScript that establishes a WebSocket connection to /ws/reload
 /// and reloads the page when a message is received.
 ///
@@ -32,10 +34,52 @@ use tokio::sync::broadcast;
 /// It is NOT present in the `index.html` file on disk.
 pub const RELOAD_SCRIPT: &str = r#"<script>
 (function() {
+  function removeOverlay() {
+    var existing = document.getElementById('__drydock_error__');
+    if (existing) existing.remove();
+  }
+
+  function showOverlay(message) {
+    removeOverlay();
+    var overlay = document.createElement('div');
+    overlay.id = '__drydock_error__';
+    overlay.style.cssText = [
+      'position: fixed',
+      'top: 0',
+      'left: 0',
+      'width: 100%',
+      'height: 100%',
+      'background: rgba(0,0,0,0.85)',
+      'color: #ff5555',
+      'font-family: monospace',
+      'font-size: 14px',
+      'padding: 2rem',
+      'box-sizing: border-box',
+      'z-index: 2147483647',
+      'white-space: pre-wrap',
+      'overflow: auto',
+    ].join(';');
+    var heading = document.createElement('div');
+    heading.style.cssText = 'font-size: 1.2rem; margin-bottom: 1rem; color: #ff5555;';
+    heading.textContent = 'Build Failed';
+    var body = document.createElement('div');
+    body.textContent = message;
+    overlay.appendChild(heading);
+    overlay.appendChild(body);
+    document.body.appendChild(overlay);
+  }
+
   function connect() {
-    const ws = new WebSocket('ws://' + location.host + '/ws/reload');
-    ws.onmessage = () => location.reload();
-    ws.onclose = () => setTimeout(connect, 1000);
+    var ws = new WebSocket('ws://' + location.host + '/ws/reload');
+    ws.onmessage = function(event) {
+      if (event.data === 'reload') {
+        removeOverlay();
+        location.reload();
+      } else if (event.data.startsWith('error:')) {
+        showOverlay(event.data.slice(6));
+      }
+    };
+    ws.onclose = function() { setTimeout(connect, 1000); };
   }
   connect();
 })();
@@ -118,7 +162,7 @@ pub fn inject_reload_script(html: &str) -> String {
 pub async fn ws_reload_handler(
     req: HttpRequest,
     body: web::Payload,
-    reload_tx: web::Data<broadcast::Sender<()>>,
+    reload_tx: web::Data<broadcast::Sender<DevServerMessage>>,
 ) -> Result<HttpResponse, actix_web::Error> {
     let peer = req
         .peer_addr()
@@ -162,9 +206,17 @@ pub async fn ws_reload_handler(
                 // Reload signal from build coordinator
                 result = reload_rx.recv() => {
                     match result {
-                        Ok(()) => {
+                        Ok(DevServerMessage::Reload) => {
                             tracing::debug!("sending reload signal to browser");
                             if session.text("reload").await.is_err() {
+                                tracing::debug!("WebSocket send failed — client disconnected");
+                                break;
+                            }
+                        }
+                        Ok(DevServerMessage::BuildError(msg)) => {
+                            tracing::debug!("sending build error to browser");
+                            let payload = format!("error:{}", msg);
+                            if session.text(payload).await.is_err() {
                                 tracing::debug!("WebSocket send failed — client disconnected");
                                 break;
                             }
@@ -273,9 +325,9 @@ mod tests {
 
     #[test]
     fn broadcast_send_with_no_receivers_does_not_panic() {
-        let (tx, _rx) = broadcast::channel::<()>(16);
+        let (tx, _rx) = broadcast::channel::<DevServerMessage>(16);
         drop(_rx);
-        let result = tx.send(());
+        let result = tx.send(DevServerMessage::Reload);
         // The send returns Err when there are no receivers
         // This is expected and acceptable behavior
         assert!(result.is_err(), "send should return Err when no receivers");
@@ -283,8 +335,8 @@ mod tests {
 
     #[test]
     fn broadcast_send_with_receivers_succeeds() {
-        let (tx, _rx) = broadcast::channel::<()>(16);
-        let result = tx.send(());
+        let (tx, _rx) = broadcast::channel::<DevServerMessage>(16);
+        let result = tx.send(DevServerMessage::Reload);
         assert!(result.is_ok(), "send should succeed when receivers exist");
     }
 }

--- a/src/dev/mod.rs
+++ b/src/dev/mod.rs
@@ -23,7 +23,8 @@
 
 // dependencies
 use crate::build::{
-    BuildConfig, FileWatcher, run_build_loop, run_wasm_pack, scss::compile_scss, start_watcher,
+    BuildConfig, DevServerMessage, FileWatcher, run_build_loop, run_wasm_pack, scss::compile_scss,
+    start_watcher,
 };
 use crate::dev::server::serve;
 use crate::domain::{ConfigError, DrydockConfig, WatchAction};
@@ -55,6 +56,10 @@ pub enum DevError {
     /// File watcher encountered an error
     #[error("file watcher error: {0}")]
     WatcherError(#[from] notify_debouncer_mini::notify::Error),
+
+    /// Initial or incremental wasm-pack build failed
+    #[error("build failed: {0}")]
+    BuildFailed(#[from] crate::build::BuildError),
 }
 
 /// Start the development server
@@ -97,14 +102,23 @@ pub async fn run(open_browser: bool) -> Result<(), DevError> {
     let config = DrydockConfig::from_file(&config_path)?;
 
     let styles_path = std::env::current_dir()?.join("frontend/styles");
-    let initial_css = compile_scss(&styles_path).unwrap_or_default();
+    let initial_css = match compile_scss(&styles_path) {
+        Ok(css) => {
+            tracing::info!("initial SCSS compiled successfully");
+            css
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "initial SCSS compilation failed — no styles will be served until fixed");
+            Vec::new()
+        }
+    };
     let css_bytes: Arc<RwLock<Vec<u8>>> = Arc::new(RwLock::new(initial_css));
 
     let mut process_manager = ProcessManager::new(&config)?;
     ProcessManager::wait_for_ready(&config).await?;
 
     let (build_tx, build_rx) = tokio::sync::mpsc::channel::<()>(8);
-    let (reload_tx, _reload_rx) = tokio::sync::broadcast::channel::<()>(16); // ← remove the underscore from _reload_rx
+    let (reload_tx, _reload_rx) = tokio::sync::broadcast::channel::<DevServerMessage>(16);
     let (restart_tx, mut restart_rx) = tokio::sync::mpsc::channel::<()>(8);
 
     // Collect all watcher handles so they don't get dropped
@@ -141,7 +155,8 @@ pub async fn run(open_browser: bool) -> Result<(), DevError> {
     let reload_tx_for_public = reload_tx.clone();
     tokio::spawn(async move {
         while let Some(()) = public_rx.recv().await {
-            let _ = reload_tx_for_public.send(());
+            tracing::info!("public asset change detected — reloading browser");
+            let _ = reload_tx_for_public.send(DevServerMessage::Reload);
         }
     });
 
@@ -159,16 +174,19 @@ pub async fn run(open_browser: bool) -> Result<(), DevError> {
     let css_bytes_for_styles = css_bytes.clone();
     tokio::spawn(async move {
         while let Some(()) = styles_rx.recv().await {
+            tracing::info!("SCSS change detected — recompiling");
             let styles_path = std::env::current_dir()
                 .expect("failed to get current dir")
                 .join("frontend/styles");
             match compile_scss(&styles_path) {
                 Ok(new_css) => {
                     *css_bytes_for_styles.write().unwrap() = new_css;
-                    let _ = reload_tx_for_styles.send(());
+                    tracing::info!("SCSS compiled successfully — reloading browser");
+                    let _ = reload_tx_for_styles.send(DevServerMessage::Reload);
                 }
                 Err(e) => {
                     tracing::warn!(error = %e, "SCSS compilation failed — previous styles still served");
+                    let _ = reload_tx_for_styles.send(DevServerMessage::BuildError(e.to_string()));
                 }
             }
         }
@@ -215,10 +233,12 @@ pub async fn run(open_browser: bool) -> Result<(), DevError> {
                 let reload = reload_tx.clone();
                 let path_for_log = watch_config.path.display().to_string();
                 let exts_for_log = watch_config.extensions.clone();
+                let path_for_trigger = path_for_log.clone();
                 watchers.push(start_watcher(&watch_path, debounce_ms, tx, extensions)?);
                 tokio::spawn(async move {
                     while let Some(()) = rx.recv().await {
-                        let _ = reload.send(());
+                        tracing::info!(path = %path_for_trigger, "custom reload watcher triggered — reloading browser");
+                        let _ = reload.send(DevServerMessage::Reload);
                     }
                 });
                 tracing::info!(
@@ -233,11 +253,13 @@ pub async fn run(open_browser: bool) -> Result<(), DevError> {
                 let build = build_tx.clone();
                 let path_for_log = watch_config.path.display().to_string();
                 let exts_for_log = watch_config.extensions.clone();
+                let path_for_trigger = path_for_log.clone();
                 watchers.push(start_watcher(&watch_path, debounce_ms, tx, extensions)?);
                 tokio::spawn(async move {
                     while let Some(()) = rx.recv().await {
+                        tracing::info!(path = %path_for_trigger, "custom rebuild watcher triggered — rebuilding");
                         let _ = build.send(()).await;
-                        let _ = reload.send(());
+                        let _ = reload.send(DevServerMessage::Reload);
                     }
                 });
                 tracing::info!(
@@ -251,9 +273,11 @@ pub async fn run(open_browser: bool) -> Result<(), DevError> {
                 let restart = restart_tx.clone();
                 let path_for_log = watch_config.path.display().to_string();
                 let exts_for_log = watch_config.extensions.clone();
+                let path_for_trigger = path_for_log.clone();
                 watchers.push(start_watcher(&watch_path, debounce_ms, tx, extensions)?);
                 tokio::spawn(async move {
                     while let Some(()) = rx.recv().await {
+                        tracing::info!(path = %path_for_trigger, "custom restart watcher triggered — restarting backend");
                         let _ = restart.send(()).await;
                     }
                 });
@@ -269,9 +293,7 @@ pub async fn run(open_browser: bool) -> Result<(), DevError> {
     let reload_tx_clone = reload_tx.clone();
     let build_config = BuildConfig::new(std::env::current_dir()?.join("frontend"));
     println!("Building frontend...");
-    run_wasm_pack(&build_config)
-        .await
-        .map_err(|_| DevError::Io(std::io::Error::other("initial wasm-pack build failed")))?;
+    run_wasm_pack(&build_config).await?;
     let build_config_for_serve = build_config.clone(); // ← clone before it moves into the spawn
     tokio::spawn(async move {
         run_build_loop(build_rx, reload_tx_clone, move || {
@@ -285,10 +307,12 @@ pub async fn run(open_browser: bool) -> Result<(), DevError> {
     let reload_tx_for_restart = reload_tx.clone();
     tokio::spawn(async move {
         while let Some(()) = restart_rx.recv().await {
+            tracing::info!("backend source change detected — restarting backend");
             if let Err(e) = process_manager.restart(&restart_config).await {
-                eprintln!("Failed to restart backend: {e}");
+                tracing::warn!(error = %e, "backend restart failed");
             } else {
-                let _ = reload_tx_for_restart.send(());
+                tracing::info!("backend restarted successfully — reloading browser");
+                let _ = reload_tx_for_restart.send(DevServerMessage::Reload);
             }
         }
     });

--- a/src/dev/server.rs
+++ b/src/dev/server.rs
@@ -2,7 +2,9 @@
 
 // dependencies
 use crate::DevMode;
-use crate::build::{BuildConfig, FileWatcher, serve_pkg_file, spa_fallback, ws_reload_handler};
+use crate::build::{
+    BuildConfig, DevServerMessage, FileWatcher, serve_pkg_file, spa_fallback, ws_reload_handler,
+};
 use crate::dev::DevError;
 use crate::dev::proxy::proxy_handler;
 use crate::dev::styles::styles_handler;
@@ -15,7 +17,7 @@ use tokio::sync::broadcast;
 pub async fn serve(
     config: &DrydockConfig,
     build_config: BuildConfig,
-    reload_tx: broadcast::Sender<()>,
+    reload_tx: broadcast::Sender<DevServerMessage>,
     css_bytes: Arc<RwLock<Vec<u8>>>,
     _watchers: Vec<FileWatcher>,
 ) -> Result<(), DevError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub mod validation;
 
 // Re-exports for convenience
 pub use build::{
-    BuildConfig, BuildError, BuildMode, DevMode, FileWatcher, run_build_loop,
+    BuildConfig, BuildError, BuildMode, DevMode, DevServerMessage, FileWatcher, run_build_loop,
     run_command_with_timeout, run_wasm_pack, run_wasm_pack_with_env, serve_pkg_file, spa_fallback,
     start_watcher,
 };

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -7,7 +7,8 @@ use actix_web::{App, test as actix_test, web};
 use tempfile::tempdir;
 use tokio::sync::broadcast;
 use wasm_drydock::{
-    BuildConfig, DevMode, RELOAD_SCRIPT, inject_reload_script, spa_fallback, ws_reload_handler,
+    BuildConfig, DevMode, DevServerMessage, RELOAD_SCRIPT, inject_reload_script, spa_fallback,
+    ws_reload_handler,
 };
 
 // =============================================================================
@@ -66,9 +67,9 @@ fn inject_reload_script_preserves_original_content() {
 
 #[test]
 fn broadcast_send_with_no_receivers_does_not_panic() {
-    let (tx, _rx) = broadcast::channel::<()>(16);
+    let (tx, _rx) = broadcast::channel::<DevServerMessage>(16);
     drop(_rx);
-    let result = tx.send(());
+    let result = tx.send(DevServerMessage::Reload);
     // The send returns Err when there are no receivers
     // This is expected and acceptable behavior
     assert!(result.is_err(), "send should return Err when no receivers");
@@ -76,8 +77,8 @@ fn broadcast_send_with_no_receivers_does_not_panic() {
 
 #[test]
 fn broadcast_send_with_receivers_succeeds() {
-    let (tx, _rx) = broadcast::channel::<()>(16);
-    let result = tx.send(());
+    let (tx, _rx) = broadcast::channel::<DevServerMessage>(16);
+    let result = tx.send(DevServerMessage::Reload);
     assert!(result.is_ok(), "send should succeed when receivers exist");
 }
 
@@ -87,7 +88,7 @@ fn broadcast_send_with_receivers_succeeds() {
 
 #[actix_web::test]
 async fn ws_endpoint_returns_101_switching_protocols() {
-    let (tx, _rx) = broadcast::channel::<()>(16);
+    let (tx, _rx) = broadcast::channel::<DevServerMessage>(16);
     let app = actix_test::init_service(
         App::new()
             .app_data(web::Data::new(tx))

--- a/tests/watcher.rs
+++ b/tests/watcher.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use tempfile::tempdir;
 use tokio::sync::{broadcast, mpsc};
-use wasm_drydock::{BuildError, run_build_loop, start_watcher};
+use wasm_drydock::{BuildError, DevServerMessage, run_build_loop, start_watcher};
 
 // =============================================================================
 // Watcher Integration Tests
@@ -119,7 +119,7 @@ fn dropping_watcher_stops_events() {
 #[tokio::test]
 async fn single_trigger_causes_one_build() {
     let (tx, rx) = mpsc::channel(8);
-    let (reload_tx, _reload_rx) = broadcast::channel::<()>(16);
+    let (reload_tx, _reload_rx) = broadcast::channel::<DevServerMessage>(16);
     let count = std::sync::Arc::new(std::sync::Mutex::new(0u32));
     let c = count.clone();
 
@@ -141,7 +141,7 @@ async fn single_trigger_causes_one_build() {
 #[tokio::test]
 async fn rapid_triggers_collapse_to_at_most_two_builds() {
     let (tx, rx) = mpsc::channel(8);
-    let (reload_tx, _reload_rx) = broadcast::channel::<()>(16);
+    let (reload_tx, _reload_rx) = broadcast::channel::<DevServerMessage>(16);
     let count = std::sync::Arc::new(std::sync::Mutex::new(0u32));
     let c = count.clone();
 
@@ -170,7 +170,7 @@ async fn rapid_triggers_collapse_to_at_most_two_builds() {
 #[tokio::test]
 async fn build_failure_does_not_block_subsequent_builds() {
     let (tx, rx) = mpsc::channel(8);
-    let (reload_tx, _reload_rx) = broadcast::channel::<()>(16);
+    let (reload_tx, _reload_rx) = broadcast::channel::<DevServerMessage>(16);
     let count = std::sync::Arc::new(std::sync::Mutex::new(0u32));
     let first = std::sync::Arc::new(std::sync::Mutex::new(true));
     let c = count.clone();
@@ -208,7 +208,7 @@ async fn build_failure_does_not_block_subsequent_builds() {
 #[tokio::test]
 async fn closed_channel_exits_loop_cleanly() {
     let (tx, rx) = mpsc::channel::<()>(8);
-    let (reload_tx, _reload_rx) = broadcast::channel::<()>(16);
+    let (reload_tx, _reload_rx) = broadcast::channel::<DevServerMessage>(16);
     let count = std::sync::Arc::new(std::sync::Mutex::new(0u32));
     let c = count.clone();
 


### PR DESCRIPTION
## Summary
This PR enhances the development server's error handling by displaying build errors directly in the browser via an overlay, rather than silently failing or requiring users to check the console.

## Key Changes

- **New `DevServerMessage` enum**: Replaces the unit type `()` in broadcast channels with a typed enum that distinguishes between successful reloads and build failures
  - `Reload`: Signals a successful build or asset change
  - `BuildError(String)`: Carries error messages to display in the browser

- **Browser error overlay UI**: Added JavaScript functions to the reload script that:
  - Display a full-screen dark overlay with error messages when builds fail
  - Remove the overlay when builds succeed
  - Style errors with monospace font and red text for visibility

- **Enhanced WebSocket protocol**: The `/ws/reload` endpoint now sends:
  - `"reload"` message for successful builds
  - `"error:<message>"` message for build failures

- **Improved error propagation**: 
  - SCSS compilation errors are now sent to connected browsers
  - Build loop failures trigger error overlays instead of silent failures
  - Initial build errors are properly surfaced via the `DevError::BuildFailed` variant

- **Better logging**: Added informative trace logs throughout the dev server for:
  - File watcher triggers (SCSS, public assets, custom watchers)
  - Backend restart events
  - Build success/failure states

## Implementation Details

- The `DevServerMessage` type is now used consistently across all broadcast channels in the build coordinator, reload handler, and dev server
- Error messages are truncated at the colon in the protocol (`"error:"` prefix) to separate the message type from content
- The overlay is positioned with `z-index: 2147483647` to ensure it appears above all other content
- All existing tests were updated to use the new `DevServerMessage::Reload` variant

https://claude.ai/code/session_011sXLpRUbUjnVCKHtx3qhsY