### PR TITLE
Add HTML file watcher to trigger browser reload on changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This starts a dev server on port 8080 that:
 - Watches `backend/src/` and restarts the backend on changes
 - Watches `frontend/styles/` and recompiles SCSS on changes
 - Watches `frontend/public/` and triggers a browser reload on changes
+- Watches `frontend/` for `.html` changes and triggers a browser reload
 - Signals the browser to reload after successful builds
 
 The generated project contains only user code — API handlers, Yew components, shared types, and styles. The tool handles everything else.
@@ -164,7 +165,7 @@ action = "rebuild"
 - Paths are relative to the project root
 - Empty `extensions` array watches all files
 - Non-existent paths are logged as warnings and skipped
-- Core watchers (`frontend/src`, `backend/src`, `frontend/public`, `frontend/styles`) are always active
+- Core watchers (`frontend/src`, `backend/src`, `frontend/public`, `frontend/styles`, `frontend/`) are always active
 
 ## Architecture
 
@@ -186,6 +187,7 @@ The tool runs four core file watchers simultaneously (always active):
 | Backend | `backend/src/` | `.rs` | Kill backend, respawn, health check, then browser reload |
 | Styles | `frontend/styles/` | `.scss` | Recompile SCSS in memory, browser reload |
 | Public assets | `frontend/public/` | any file | Browser reload |
+| HTML | `frontend/` | `.html` | Browser reload |
 
 Additional custom watchers can be configured via `[[watch]]` entries in `drydock.toml` (see [Custom Watch Paths](#custom-watch-paths)).
 

--- a/src/dev/mod.rs
+++ b/src/dev/mod.rs
@@ -192,6 +192,24 @@ pub async fn run(open_browser: bool) -> Result<(), DevError> {
         }
     });
 
+    // Core watcher: frontend/*.html → Page reload
+    let (html_tx, mut html_rx) = tokio::sync::mpsc::channel::<()>(8);
+    let html_watch_path = std::env::current_dir()?.join("frontend");
+    watchers.push(start_watcher(
+        &html_watch_path,
+        config.dev.watch_debounce_ms,
+        html_tx,
+        Some(&["html"]),
+    )?);
+
+    let reload_tx_for_html = reload_tx.clone();
+    tokio::spawn(async move {
+        while let Some(()) = html_rx.recv().await {
+            tracing::info!("HTML change detected — reloading browser");
+            let _ = reload_tx_for_html.send(DevServerMessage::Reload);
+        }
+    });
+
     // Custom watchers from configuration
     // Clone the watch configs to avoid lifetime issues with the loop
     let custom_watches: Vec<_> = config.watch.clone();


### PR DESCRIPTION
## Summary
Added a new core file watcher that monitors `frontend/` for `.html` file changes and triggers a browser reload, complementing the existing watchers for backend code, styles, and public assets.

## Key Changes
- **New HTML watcher**: Added a dedicated watcher in `src/dev/mod.rs` that monitors the `frontend/` directory for `.html` files and sends reload signals to connected browsers
- **Documentation updates**: Updated README.md to reflect the new HTML watcher as part of the core watchers list and added it to the architecture table

## Implementation Details
- The HTML watcher follows the same pattern as existing watchers, using a tokio channel to communicate file change events
- Respects the configured `watch_debounce_ms` setting for debouncing rapid file changes
- Integrates seamlessly with the existing reload broadcast system, sending `DevServerMessage::Reload` to trigger browser refresh
- Logs informational messages when HTML changes are detected

https://claude.ai/code/session_015A3SWcGznyk4RXDcyaSjDZ