### PR TITLE
Add comprehensive documentation for wasm-drydock

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,9 @@
+[book]
+title = "wasm-drydock"
+authors = ["Jeffery D. Mitchell"]
+language = "en"
+src = "src"
+
+[output.html]
+git-repository-url = "https://github.com/crustyrustacean/wasm-drydock"
+edit-url-template = "https://github.com/crustyrustacean/wasm-drydock/edit/trunk/docs/src/{path}"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,51 @@
+# Summary
+
+[Introduction](./introduction.md)
+
+# Getting Started
+
+- [Overview](./getting-started/README.md)
+- [Installation](./getting-started/installation.md)
+- [Creating a Project](./getting-started/creating-a-project.md)
+- [The Dev Server](./getting-started/dev-server.md)
+- [Release Build](./getting-started/release-build.md)
+
+# Project Structure
+
+- [Overview](./project-structure/README.md)
+- [Workspace](./project-structure/workspace.md)
+- [Backend](./project-structure/backend.md)
+- [Frontend](./project-structure/frontend.md)
+- [Shared](./project-structure/shared.md)
+
+# Dev Server
+
+- [Overview](./dev-server/README.md)
+- [File Watchers](./dev-server/watchers.md)
+- [Hot Reload](./dev-server/hot-reload.md)
+- [Error Overlay](./dev-server/error-overlay.md)
+- [SCSS Compilation](./dev-server/scss.md)
+
+# Configuration
+
+- [Overview](./configuration/README.md)
+- [Reference](./configuration/reference.md)
+
+# Building & Deployment
+
+- [Overview](./building-and-deployment/README.md)
+- [Release Binary](./building-and-deployment/release-binary.md)
+- [Docker](./building-and-deployment/docker.md)
+- [Fly.io](./building-and-deployment/fly-io.md)
+
+# Architecture
+
+- [Overview](./architecture/README.md)
+- [Build Coordinator](./architecture/build-coordinator.md)
+- [Process Manager](./architecture/process-manager.md)
+- [Reload Channel](./architecture/reload-channel.md)
+- [Static Assets](./architecture/static-assets.md)
+
+# Resources
+
+- [Resources](./resources/README.md)

--- a/docs/src/architecture/README.md
+++ b/docs/src/architecture/README.md
@@ -1,0 +1,8 @@
+# Architecture
+
+This section covers the internal design of the wasm-drydock dev server.
+
+- [Build Coordinator](./build-coordinator.md) — serializes rebuild requests and coalesces rapid file changes
+- [Process Manager](./process-manager.md) — owns the backend child process and handles restarts
+- [Reload Channel](./reload-channel.md) — broadcasts reload and error messages to connected browser tabs
+- [Static Assets](./static-assets.md) — how assets are served differently in development and release modes

--- a/docs/src/architecture/build-coordinator.md
+++ b/docs/src/architecture/build-coordinator.md
@@ -1,0 +1,23 @@
+# Build Coordinator
+
+`src/build/build_coordinator.rs`
+
+The build coordinator serializes rebuild requests, ensuring builds never run concurrently and that rapid file changes don't trigger redundant builds.
+
+## Coalescing
+
+The coordinator implements a one-pending-build policy:
+
+- If a build is running and a new trigger arrives, the trigger is noted as pending
+- When the running build finishes, the pending build starts immediately
+- Additional triggers that arrive while a build is running and one is already pending are discarded
+
+This means at most two builds are ever queued: one running and one pending.
+
+## Error handling
+
+Build failures are logged at `warn` level but do not exit the loop. The server continues running and serving the last successful build. Only channel closure exits the loop.
+
+## Reload signaling
+
+After a successful build, a `DevServerMessage::Reload` is sent on the broadcast channel. After a failed build, a `DevServerMessage::BuildError` is sent, which the browser displays as an error overlay.

--- a/docs/src/architecture/process-manager.md
+++ b/docs/src/architecture/process-manager.md
@@ -1,0 +1,24 @@
+# Process Manager
+
+`src/dev/mod.rs`
+
+The `ProcessManager` struct owns the backend child process for the lifetime of the dev server.
+
+## Lifecycle
+
+On `new()`, the backend is spawned via `tokio::process::Command` with `kill_on_drop(true)`. This means the backend process is automatically killed if `ProcessManager` is dropped for any reason — clean exit, panic, or error propagation.
+
+## Restart
+
+When a change is detected in `backend/src/`, `ProcessManager::restart()` is called:
+
+1. The existing child process is taken from the `Option`, killed, and awaited
+2. A new backend process is spawned
+3. The dev server polls `/api/health_check` until the new backend is ready
+4. A reload signal is sent to connected browsers
+
+Both `kill()` and `wait()` are async operations using `tokio::process::Child`, so they yield properly and do not block the Tokio runtime.
+
+## Graceful shutdown
+
+`kill_on_drop(true)` on `tokio::process::Child` ensures the backend process is cleaned up on any exit path without requiring an explicit `Drop` implementation.

--- a/docs/src/architecture/reload-channel.md
+++ b/docs/src/architecture/reload-channel.md
@@ -1,0 +1,33 @@
+# Reload Channel
+
+`src/build/reload.rs`
+
+The reload channel is a `tokio::sync::broadcast` channel that carries `DevServerMessage` values from the server to all connected browser tabs.
+
+## Message types
+
+```rust
+pub enum DevServerMessage {
+    Reload,
+    BuildError(String),
+}
+```
+
+## Flow
+
+1. A watcher detects a file change and sends a trigger to the build coordinator
+2. The build coordinator runs the build
+3. On success, it sends `DevServerMessage::Reload` on the broadcast channel
+4. On failure, it sends `DevServerMessage::BuildError(message)`
+5. The WebSocket handler receives the message and forwards it to the browser
+6. The browser either reloads or displays the error overlay
+
+## WebSocket handler
+
+`ws_reload_handler` upgrades the HTTP connection to WebSocket and subscribes to the broadcast channel. It handles:
+
+- `Reload` — sends `"reload"` text frame
+- `BuildError` — sends `"error:<message>"` text frame
+- `RecvError::Lagged` — subscriber fell behind, sends one reload
+- `RecvError::Closed` — broadcast channel closed, exits loop
+- Client disconnect — exits loop cleanly

--- a/docs/src/architecture/static-assets.md
+++ b/docs/src/architecture/static-assets.md
@@ -1,0 +1,28 @@
+# Static Assets
+
+Static asset serving behaves differently in development and release modes.
+
+## Development mode
+
+Assets are served from the filesystem at runtime:
+
+- `/pkg/*` — files from `frontend/pkg/` (wasm-pack output)
+- `/styles/screen.css` — CSS compiled from SCSS, held in memory
+- `/favicon.png` and other public files — files from `frontend/public/`
+- `/*` — SPA fallback serves `frontend/index.html` with the reload script injected
+
+## Release mode (`embed-assets` feature)
+
+All assets are embedded into the binary at compile time:
+
+- `frontend/pkg/` — embedded via `include_dir!`
+- `frontend/index.html` — embedded via `include_bytes!`
+- `frontend/styles/screen.css` — embedded via `include_bytes!`
+- `frontend/public/` — embedded via `include_dir!`
+- `configuration/base.yaml` — embedded via `include_str!`
+
+No filesystem access is required at runtime. The binary is fully self-contained.
+
+## Path traversal protection
+
+All asset handlers extract only the final path component via `Path::file_name()` before serving. This prevents path traversal attacks such as `/pkg/../../etc/passwd`.

--- a/docs/src/building-and-deployment/README.md
+++ b/docs/src/building-and-deployment/README.md
@@ -1,0 +1,7 @@
+# Building & Deployment
+
+wasm-drydock produces a single self-contained binary that embeds all frontend assets. This makes deployment straightforward — there is no separate static file server to manage.
+
+- [Release Binary](./release-binary.md) — build a release binary with `wasm-drydock release`
+- [Docker](./docker.md) — build a minimal production image using the generated `Dockerfile`
+- [Fly.io](./fly-io.md) — deploy to Fly.io with `fly deploy`

--- a/docs/src/building-and-deployment/docker.md
+++ b/docs/src/building-and-deployment/docker.md
@@ -1,0 +1,35 @@
+# Docker
+
+A `Dockerfile` is included in every project scaffolded by `wasm-drydock init`. It uses a multi-stage build to produce a minimal production image.
+
+## Build stages
+
+**`chef`** — base image with all build tools installed:
+- Rust toolchain
+- wasm-pack
+- wasm32-unknown-unknown target
+- cargo-chef for dependency caching
+
+**`planner`** — analyses the dependency graph and produces `recipe.json`
+
+**`builder`** — cooks dependencies from `recipe.json`, then builds the project:
+1. `wasm-pack build --release` on the frontend
+2. `grass` compiles SCSS to CSS
+3. `cargo build --release --features embed-assets` on the backend
+
+**Final stage** — copies only the release binary into a minimal `debian:bookworm-slim` image.
+
+## Building
+
+```bash
+docker build -t my-app .
+```
+
+## Running
+
+```bash
+docker run -p 3001:3001 \
+  -e APP_ENVIRONMENT=production \
+  -e APP_APPLICATION__HOST=0.0.0.0 \
+  my-app
+```

--- a/docs/src/building-and-deployment/fly-io.md
+++ b/docs/src/building-and-deployment/fly-io.md
@@ -1,0 +1,53 @@
+# Fly.io
+
+## Prerequisites
+
+- [flyctl](https://fly.io/docs/hands-on/install-flyctl/) installed and authenticated
+
+## Setup
+
+Register the app with Fly without deploying:
+
+```bash
+fly launch --no-deploy
+```
+
+## `fly.toml`
+
+```toml
+app = "your-app-name"
+primary_region = "yyz"
+
+[build]
+
+[env]
+  APP_ENVIRONMENT = "production"
+  APP_APPLICATION__HOST = "0.0.0.0"
+
+[http_service]
+  internal_port = 3001
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"
+```
+
+## Deploying
+
+```bash
+fly deploy
+```
+
+The Docker build runs on your local machine. The resulting image is pushed to Fly's registry and deployed.
+
+## Custom domain
+
+Add your domain in the Fly dashboard under **Certificates**, then point your DNS at Fly's servers. Fly provisions the TLS certificate automatically.
+
+## Important: bind address
+
+Fly's proxy routes external traffic to your app's internal port. Your app must bind to `0.0.0.0` rather than `127.0.0.1`. The `APP_APPLICATION__HOST = "0.0.0.0"` environment variable in `fly.toml` handles this.

--- a/docs/src/building-and-deployment/release-binary.md
+++ b/docs/src/building-and-deployment/release-binary.md
@@ -1,0 +1,47 @@
+# Release Binary
+
+```bash
+wasm-drydock release
+```
+
+This command:
+
+1. Runs `wasm-pack build --release` on the frontend
+2. Compiles `frontend/styles/screen.scss` to `frontend/styles/screen.css`
+3. Runs `cargo build --release --features embed-assets` on the backend
+
+The result is a single self-contained binary in `target/release/` with all frontend assets — WASM, JavaScript, CSS, `index.html`, and public assets — compiled in via the `embed-assets` feature flag.
+
+## What is embedded
+
+| Asset | Source | Mechanism |
+|-------|--------|-----------|
+| WASM and JS | `frontend/pkg/` | `include_dir!` |
+| HTML | `frontend/index.html` | `include_bytes!` |
+| CSS | `frontend/styles/screen.css` | `include_bytes!` |
+| Public files | `frontend/public/` | `include_dir!` |
+| Configuration | `configuration/base.yaml` | `include_str!` |
+
+The binary has zero runtime filesystem dependencies.
+
+## Running the release binary
+
+```bash
+./target/release/my-app-backend
+```
+
+## Configuration at runtime
+
+The release binary embeds `configuration/base.yaml` at compile time. To override settings at runtime without recompiling, place an environment-specific YAML file next to the binary:
+
+```
+my-app-backend          ← the binary
+configuration/
+└── production.yaml     ← optional override
+```
+
+`APP_*` environment variables are always applied last and override everything:
+
+```bash
+APP_APPLICATION__HOST=0.0.0.0 ./my-app-backend
+```

--- a/docs/src/configuration/README.md
+++ b/docs/src/configuration/README.md
@@ -1,0 +1,5 @@
+# Configuration
+
+wasm-drydock is configured via `drydock.toml` at the workspace root. The file is created automatically by `wasm-drydock init` and contains sensible defaults that work for most projects.
+
+- [Reference](./reference.md) — complete field-by-field reference for `drydock.toml`, including `[[watch]]` entries and environment variable overrides

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -1,0 +1,48 @@
+# Configuration Reference
+
+`drydock.toml` lives at the workspace root. All `[dev]` fields are optional and fall back to the defaults shown.
+
+```toml
+[project]
+name = "my-app"
+
+[dev]
+public_port = 8080          # browser-facing port
+backend_port = 3001         # internal backend port
+watch_debounce_ms = 300     # file change debounce interval in milliseconds
+```
+
+## `[project]`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | The project name. Used to identify the backend binary. |
+
+## `[dev]`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `public_port` | integer | `8080` | The port the dev server binds to |
+| `backend_port` | integer | `3001` | The port the backend process binds to |
+| `watch_debounce_ms` | integer | `300` | Milliseconds to wait after a file change before triggering a rebuild |
+
+## `[[watch]]`
+
+Zero or more custom watch entries. Each entry has the following fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | string | yes | Path to watch, relative to the project root |
+| `extensions` | array of strings | no | File extensions to filter. Empty array watches all files. |
+| `action` | string | yes | One of `"reload"`, `"rebuild"`, `"restart"` |
+
+## Environment variables
+
+The backend respects the following environment variables at runtime:
+
+| Variable | Description |
+|----------|-------------|
+| `DRYDOCK_BACKEND_PORT` | Overrides the backend port. Set automatically by the dev server. |
+| `APP_ENVIRONMENT` | Selects the environment config file (`local` or `production`). Defaults to `local`. |
+| `APP_APPLICATION__HOST` | Overrides the bind host. Use `0.0.0.0` for production deployments. |
+| `APP_APPLICATION__PORT` | Overrides the bind port. |

--- a/docs/src/dev-server/README.md
+++ b/docs/src/dev-server/README.md
@@ -1,0 +1,8 @@
+# Dev Server
+
+The wasm-drydock dev server owns the entire development loop — frontend builds, backend process management, file watching, live reload, and SCSS compilation — under a single command.
+
+- [File Watchers](./watchers.md) — the five core watchers and how to configure custom watch paths
+- [Hot Reload](./hot-reload.md) — how the browser is signalled to reload after a successful build
+- [Error Overlay](./error-overlay.md) — how build failures are surfaced in the browser
+- [SCSS Compilation](./scss.md) — in-memory SCSS compilation with the `grass` compiler

--- a/docs/src/dev-server/error-overlay.md
+++ b/docs/src/dev-server/error-overlay.md
@@ -1,0 +1,14 @@
+# Error Overlay
+
+When a build fails during a watch cycle, the error message is sent to all connected browser tabs via WebSocket. The browser displays a full-screen overlay showing the error.
+
+The overlay:
+
+- Appears immediately when a build failure is detected
+- Shows the full error message from the build tool
+- Is dismissed automatically when the next successful build completes
+- Does not require a page refresh to appear or disappear
+
+This means you can keep your browser and editor side by side — build errors surface in the browser without needing to switch to the terminal.
+
+SCSS compilation failures during a watch cycle are also surfaced via the overlay.

--- a/docs/src/dev-server/hot-reload.md
+++ b/docs/src/dev-server/hot-reload.md
@@ -1,0 +1,12 @@
+# Hot Reload
+
+The dev server injects a small JavaScript snippet into `index.html` before serving it in development mode. This snippet establishes a WebSocket connection to `/ws/reload`.
+
+When a build or reload event occurs, the server sends a message over the WebSocket:
+
+- `"reload"` — the browser reloads the page
+- `"error:<message>"` — the browser displays the error overlay
+
+The snippet reconnects automatically if the WebSocket connection drops, with a one second delay. This means the browser reconnects seamlessly if the dev server restarts.
+
+The reload script is never present in release builds.

--- a/docs/src/dev-server/scss.md
+++ b/docs/src/dev-server/scss.md
@@ -1,0 +1,16 @@
+# SCSS Compilation
+
+The dev server compiles `frontend/styles/screen.scss` using the `grass` SCSS compiler and serves the result at `/styles/screen.css`.
+
+Compilation happens:
+
+- On startup
+- Whenever a `.scss` file in `frontend/styles/` changes
+
+The compiled CSS is held in memory and never written to disk during development. `frontend/styles/screen.css` is listed in `.gitignore` for this reason.
+
+If SCSS compilation fails at startup, a warning is logged and the server continues with an empty stylesheet. The error overlay will display the compiler message on subsequent failures during the watch cycle.
+
+## Release builds
+
+`wasm-drydock release` writes `frontend/styles/screen.css` to disk so it can be embedded into the release binary.

--- a/docs/src/dev-server/watchers.md
+++ b/docs/src/dev-server/watchers.md
@@ -1,0 +1,48 @@
+# File Watchers
+
+## Core watchers
+
+Five core watchers run at all times:
+
+| Watcher | Path | Filters | On change |
+|---------|------|---------|-----------|
+| Frontend | `frontend/src/` | `.rs` | `wasm-pack build`, then browser reload |
+| Backend | `backend/src/` | `.rs` | Kill backend, respawn, health check, then browser reload |
+| Styles | `frontend/styles/` | `.scss` | Recompile SCSS in memory, browser reload |
+| Public assets | `frontend/public/` | any file | Browser reload |
+| HTML | `frontend/` | `.html` | Browser reload |
+
+## Custom watch paths
+
+Additional watch paths can be configured in `drydock.toml` using `[[watch]]` entries:
+
+```toml
+[[watch]]
+path = "frontend/content"
+extensions = ["md", "mdx"]
+action = "reload"
+
+[[watch]]
+path = "frontend/assets"
+extensions = []
+action = "reload"
+
+[[watch]]
+path = "shared/src"
+extensions = ["rs"]
+action = "rebuild"
+```
+
+### Available actions
+
+| Action | Effect |
+|--------|--------|
+| `reload` | Trigger browser page reload |
+| `rebuild` | Trigger WASM rebuild then reload |
+| `restart` | Trigger backend restart |
+
+### Notes
+
+- Paths are relative to the project root
+- Empty `extensions` array watches all files
+- Non-existent paths are logged as warnings and skipped

--- a/docs/src/getting-started/README.md
+++ b/docs/src/getting-started/README.md
@@ -1,0 +1,8 @@
+# Getting Started
+
+This section walks you through everything you need to go from zero to a running wasm-drydock project.
+
+- [Installation](./installation.md) — install the prerequisites and wasm-drydock itself
+- [Creating a Project](./creating-a-project.md) — scaffold a new three-crate workspace with `wasm-drydock init`
+- [The Dev Server](./dev-server.md) — start the dev server and understand what it does
+- [Release Build](./release-build.md) — produce a self-contained release binary

--- a/docs/src/getting-started/creating-a-project.md
+++ b/docs/src/getting-started/creating-a-project.md
@@ -1,0 +1,34 @@
+# Creating a Project
+
+## Scaffold a new project
+
+```bash
+wasm-drydock init my-app
+cd my-app
+```
+
+`wasm-drydock init` validates your environment before scaffolding — it checks that `wasm-pack` is installed, meets the minimum version requirement, and that the `wasm32-unknown-unknown` target is present. If any check fails, it reports the problem and exits cleanly.
+
+The generated project is a three-crate Cargo workspace:
+
+```
+my-app/
+├── .cargo/config.toml
+├── .gitignore
+├── Cargo.toml
+├── drydock.toml
+├── backend/
+├── frontend/
+└── shared/
+```
+
+See [Project Structure](../project-structure/README.md) for a detailed walkthrough of what each crate contains and why.
+
+## Project name rules
+
+Project names follow Cargo conventions:
+
+- 1–64 characters
+- Alphanumeric characters, hyphens, and underscores only
+- Cannot start with a hyphen or underscore
+- Cannot be a Rust keyword or reserved Cargo command name

--- a/docs/src/getting-started/dev-server.md
+++ b/docs/src/getting-started/dev-server.md
@@ -1,0 +1,50 @@
+# The Dev Server
+
+## Starting the server
+
+From your project root:
+
+```bash
+wasm-drydock dev
+```
+
+On startup the dev server:
+
+1. Compiles `frontend/styles/screen.scss` to CSS
+2. Spawns the backend process and polls `/api/health_check` until it responds
+3. Runs an initial `wasm-pack build` on the frontend
+4. Starts the HTTP server on `http://localhost:8080`
+
+## Opening the browser automatically
+
+```bash
+wasm-drydock dev --open
+```
+
+## What the server handles
+
+| Path | Behaviour |
+|------|-----------|
+| `/api/*` | Proxied to the backend |
+| `/pkg/*` | Serves wasm-pack build output |
+| `/styles/screen.css` | Serves compiled SCSS |
+| `/ws/reload` | WebSocket live reload endpoint |
+| `/*` | SPA fallback — serves `index.html` |
+
+## File watchers
+
+The dev server runs five core watchers simultaneously:
+
+| Watcher | Path | Filters | On change |
+|---------|------|---------|-----------|
+| Frontend | `frontend/src/` | `.rs` | `wasm-pack build`, then browser reload |
+| Backend | `backend/src/` | `.rs` | Kill backend, respawn, health check, then browser reload |
+| Styles | `frontend/styles/` | `.scss` | Recompile SCSS in memory, browser reload |
+| Public assets | `frontend/public/` | any file | Browser reload |
+| HTML | `frontend/` | `.html` | Browser reload |
+
+See [File Watchers](../dev-server/watchers.md) for custom watch path configuration.
+
+## Error overlay
+
+When a build fails, the error is pushed to the browser via WebSocket and displayed as a full-screen overlay. The overlay is dismissed automatically when the next successful build completes.

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -1,0 +1,51 @@
+# Installation
+
+## Prerequisites
+
+Before installing wasm-drydock, ensure the following are available on your system.
+
+**Rust toolchain (edition 2024)**
+
+Install via [rustup](https://rustup.rs):
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+**wasm-pack**
+
+wasm-drydock uses wasm-pack to compile your Yew frontend to WebAssembly.
+
+```bash
+curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+```
+
+Minimum required version: `0.13.0`. Verify with:
+
+```bash
+wasm-pack --version
+```
+
+**wasm32-unknown-unknown target**
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+## Installing wasm-drydock
+
+```bash
+cargo install wasm-drydock
+```
+
+Verify the installation:
+
+```bash
+wasm-drydock --help
+```
+
+## Updating
+
+```bash
+cargo install wasm-drydock --force
+```

--- a/docs/src/getting-started/release-build.md
+++ b/docs/src/getting-started/release-build.md
@@ -1,0 +1,29 @@
+# Release Build
+
+```bash
+wasm-drydock release
+```
+
+This command:
+
+1. Runs `wasm-pack build --release` on the frontend
+2. Compiles `frontend/styles/screen.scss` to `frontend/styles/screen.css`
+3. Runs `cargo build --release --features embed-assets` on the backend
+
+The result is a single self-contained binary in `target/release/` with all frontend assets — WASM, JavaScript, CSS, `index.html`, and public assets — compiled in. The binary has zero runtime filesystem dependencies.
+
+## Configuration at runtime
+
+The release binary embeds `configuration/base.yaml` at compile time. To override settings at runtime without recompiling, place an environment-specific YAML file next to the binary:
+
+```
+my-app-backend          ← the binary
+configuration/
+└── production.yaml     ← optional override
+```
+
+`APP_*` environment variables are always applied last and override everything:
+
+```bash
+APP_APPLICATION__HOST=0.0.0.0 ./my-app-backend
+```

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,0 +1,29 @@
+# wasm-drydock
+
+wasm-drydock is a single-command dev tool for fullstack Rust web applications using **Actix-web** and **Yew**.
+
+Most fullstack Rust setups require you to manage two separate processes: one for the frontend WASM build and one for the backend server. wasm-drydock replaces both with a single command that owns the entire development loop.
+
+## What it does
+
+```
+wasm-drydock dev
+```
+
+This starts a dev server that:
+
+- Builds the frontend with `wasm-pack` on startup
+- Spawns your Actix-web backend and waits for it to be ready
+- Proxies `/api/*` requests to the backend
+- Watches source files and rebuilds on changes
+- Recompiles SCSS on the fly
+- Pushes build errors directly to the browser
+- Signals the browser to reload after successful builds
+
+When you are ready to ship, `wasm-drydock release` produces a single self-contained binary with all frontend assets compiled in — no separate static file server required.
+
+## Prerequisites
+
+- **Rust** (edition 2024)
+- **wasm-pack** >= 0.13.0
+- **wasm32-unknown-unknown** target: `rustup target add wasm32-unknown-unknown`

--- a/docs/src/project-structure/README.md
+++ b/docs/src/project-structure/README.md
@@ -1,0 +1,11 @@
+# Project Structure
+
+A wasm-drydock project is a three-crate Cargo workspace. Each crate has a clearly defined responsibility:
+
+| Crate | Purpose |
+|-------|---------|
+| `backend/` | Actix-web API server |
+| `frontend/` | Yew WASM application |
+| `shared/` | Serde-compatible API types |
+
+The `shared` crate is the boundary between frontend and backend. Both crates depend on it, so serialization mismatches become compile errors rather than runtime surprises.

--- a/docs/src/project-structure/backend.md
+++ b/docs/src/project-structure/backend.md
@@ -1,0 +1,21 @@
+# Backend
+
+The scaffolded backend is an opinionated Actix-web starter. It is structured around a small set of focused modules:
+
+- **`configuration.rs`** — YAML-based configuration loading. Walks up the directory tree to find `configuration/base.yaml`. Respects the `DRYDOCK_BACKEND_PORT` environment variable set by the dev server.
+- **`startup.rs`** — Wires up the Actix-web server, routes, and middleware.
+- **`error.rs`** — `ApiError` enum implementing `ResponseError`, mapping variants to HTTP status codes.
+- **`response.rs`** — Re-exports `ApiResponse<T>` from the shared crate for use in handlers.
+- **`telemetry.rs`** — Tracing subscriber setup with Bunyan-formatted JSON output.
+- **`static_assets.rs`** — Serves embedded frontend assets in release builds. Compiled out in development.
+- **`api/mod.rs`** — Route configuration with starter endpoints: `/api/health_check`, `/api/hello`, `/api/status`.
+
+## Integration tests
+
+Integration test scaffolding lives in `backend/tests/api/` with a `TestApp` helper that spawns the server on a random port, plus a sample health check test to build on.
+
+## Feature flags
+
+| Flag | Effect |
+|------|--------|
+| `embed-assets` | Embeds all frontend assets and `configuration/base.yaml` into the binary at compile time |

--- a/docs/src/project-structure/frontend.md
+++ b/docs/src/project-structure/frontend.md
@@ -1,0 +1,30 @@
+# Frontend
+
+The frontend is a Yew CSR application compiled to WebAssembly via wasm-pack.
+
+## Entry point
+
+`frontend/src/lib.rs` contains the root `App` component and the `#[wasm_bindgen(start)]` entry point that initialises the logger, panic hook, and Yew renderer.
+
+## Styles
+
+SCSS lives in `frontend/styles/screen.scss`. The dev server compiles it to CSS in memory and serves it at `/styles/screen.css`. It is never written to disk during development — the compiled `screen.css` is only produced by `wasm-drydock release`.
+
+A CSS reset based on Josh Comeau's modern reset is included by default.
+
+## Public assets
+
+Static files placed in `frontend/public/` are served as-is at their filename. For example, `frontend/public/favicon.png` is served at `/favicon.png`.
+
+## index.html
+
+`frontend/index.html` bootstraps the application. The WASM module is loaded via an ES module script:
+
+```html
+<script type="module">
+    import init from '/pkg/my_app_frontend.js';
+    init();
+</script>
+```
+
+Note the absolute path — relative paths break on SPA subroutes.

--- a/docs/src/project-structure/shared.md
+++ b/docs/src/project-structure/shared.md
@@ -1,0 +1,29 @@
+# Shared
+
+The `shared` crate contains the API boundary types used by both `backend` and `frontend`.
+
+Both crates depend on `shared`, so serialization mismatches between the API and the frontend are caught at compile time rather than at runtime.
+
+## Types
+
+```rust
+pub struct ApiResponse<T> {
+    pub success: bool,
+    pub data: Option<T>,
+    pub error: Option<String>,
+}
+
+pub struct HelloResponse {
+    pub message: String,
+}
+
+pub struct StatusResponse {
+    pub version: String,
+    pub uptime_seconds: u64,
+}
+```
+
+## Design notes
+
+- Types do not use `#[serde(deny_unknown_fields)]` — unknown fields are silently ignored, which ensures forward compatibility as the API evolves
+- Compile-time assertions verify that all types implement `Serialize` and `Deserialize`

--- a/docs/src/project-structure/workspace.md
+++ b/docs/src/project-structure/workspace.md
@@ -1,0 +1,39 @@
+# Workspace
+
+A wasm-drydock project is a Cargo workspace containing three member crates: `backend`, `frontend`, and `shared`.
+
+## `Cargo.toml`
+
+The workspace manifest at the project root lists all three members and pins shared dependency versions in `[workspace.dependencies]`:
+
+```toml
+[workspace]
+members = ["backend", "frontend", "shared"]
+resolver = "2"
+
+[workspace.dependencies]
+serde = { version = "1", features = ["derive"] }
+```
+
+## `.cargo/config.toml`
+
+The workspace-level Cargo configuration sets the default build target for the `frontend` crate:
+
+```toml
+[build]
+target = "wasm32-unknown-unknown"
+```
+
+> **Note:** This applies only when building inside the `frontend` crate directory. wasm-drydock handles target selection automatically when invoking `wasm-pack`.
+
+## `drydock.toml`
+
+The wasm-drydock configuration file at the workspace root. See [Configuration Reference](../configuration/reference.md) for all available fields.
+
+## `.gitignore`
+
+The generated `.gitignore` excludes:
+
+- `target/` — Cargo build output
+- `frontend/pkg/` — wasm-pack build output
+- `frontend/styles/screen.css` — compiled SCSS (only written by `wasm-drydock release`)

--- a/docs/src/resources/README.md
+++ b/docs/src/resources/README.md
@@ -1,0 +1,43 @@
+# Resources
+
+A curated list of resources for the technologies wasm-drydock is built on and around.
+
+## WebAssembly
+
+- [WebAssembly Official Site](https://webassembly.org) — specification, concepts, and use cases
+- [Rust and WebAssembly Book](https://rustwasm.github.io/docs/book/) — the definitive guide to compiling Rust to WASM
+- [wasm-pack](https://rustwasm.github.io/wasm-pack/) — the tool wasm-drydock uses to build your frontend
+- [wasm-bindgen](https://rustwasm.github.io/docs/wasm-bindgen/) — how Rust and JavaScript interoperate at the WASM boundary
+
+## Yew
+
+- [Yew Documentation](https://yew.rs/docs/getting-started/introduction) — components, hooks, routing, and more
+- [Yew 0.22 Release Notes](https://yew.rs/blog/2025/11/29/release-0-22) — what changed in the version wasm-drydock targets
+- [Yew GitHub](https://github.com/yewstack/yew)
+- [gloo](https://github.com/rustwasm/gloo) — toolkit for building WASM applications, used by Yew internally
+
+## Actix-web
+
+- [Actix-web Documentation](https://actix.rs/docs/) — handlers, middleware, extractors
+- [Actix-web API Reference](https://docs.rs/actix-web) — full API docs on docs.rs
+
+## Trunk
+
+- [Trunk](https://trunkrs.dev) — the WASM bundler wasm-drydock does not use but which you may encounter in the Yew ecosystem. Understanding trunk helps clarify what wasm-drydock replaces.
+
+## Rust Async
+
+- [Tokio Documentation](https://tokio.rs) — the async runtime wasm-drydock is built on
+- [Tokio Tutorial](https://tokio.rs/tokio/tutorial) — recommended reading for understanding the async foundations
+
+## Deployment
+
+- [Fly.io Documentation](https://fly.io/docs/) — the deployment platform covered in this guide
+- [cargo-chef](https://github.com/LukeMathWalker/cargo-chef) — Docker layer caching for Rust projects, used in the wasm-drydock Dockerfile
+- [Caddy](https://caddyserver.com) — a simple reverse proxy with automatic HTTPS, a good alternative to Fly for VPS deployments
+
+## Related Projects
+
+- [Leptos](https://leptos.dev) — a full-stack Rust framework with SSR support, worth knowing about as the ecosystem matures
+- [Dioxus](https://dioxuslabs.com) — another Rust UI framework targeting multiple platforms including WASM
+- [cargo-generate](https://github.com/cargo-generate/cargo-generate) — template-based project scaffolding, an alternative approach to what wasm-drydock's `init` command does


### PR DESCRIPTION
This PR adds a complete mdBook documentation site for wasm-drydock, covering installation, project structure, development workflow, configuration, deployment, and internal architecture.

## Summary

The documentation is organized into seven main sections:

- **Getting Started** — Prerequisites, installation, project scaffolding, dev server usage, and release builds
- **Project Structure** — Workspace layout, backend/frontend/shared crate responsibilities, and configuration files
- **Dev Server** — File watchers, hot reload mechanism, error overlay, and SCSS compilation
- **Configuration** — `drydock.toml` reference with all available options and environment variables
- **Building & Deployment** — Release binary creation, Docker multi-stage builds, and Fly.io deployment guide
- **Architecture** — Internal design of the build coordinator, process manager, reload channel, and static asset serving
- **Resources** — Curated links to WebAssembly, Yew, Actix-web, Tokio, and deployment platform documentation

## Key Changes

- Added `book.toml` with mdBook configuration pointing to GitHub repository
- Created `SUMMARY.md` with complete table of contents for all documentation sections
- Documented installation prerequisites (Rust, wasm-pack, wasm32-unknown-unknown target)
- Explained three-crate workspace structure and the role of each crate
- Detailed dev server architecture including file watchers, build coalescing, and WebSocket-based reload signaling
- Provided configuration reference for `drydock.toml` with all `[dev]` and `[[watch]]` options
- Included Docker multi-stage build explanation and Fly.io deployment walkthrough
- Documented internal components: build coordinator, process manager, reload channel, and static asset embedding

## Notable Details

- Documentation emphasizes the single-command dev experience and zero-filesystem-dependency release binaries
- Architecture section explains how rapid file changes are coalesced to prevent redundant builds
- Deployment guides cover both containerized (Docker/Fly.io) and binary distribution approaches
- Resources section provides context for the underlying technologies (Yew, Actix-web, Tokio, wasm-pack)

https://claude.ai/code/session_01S8mZwujuCzeDRkDzka3PNS